### PR TITLE
Introduce new default "unknown" activity state

### DIFF
--- a/solace/templates/solaceConfigMap.yaml
+++ b/solace/templates/solaceConfigMap.yaml
@@ -210,7 +210,7 @@ data:
     state_file=/tmp/activity_state
     if [ ! -f ${state_file} ]; then
       echo "State file not found, creating!"
-      echo "false" > ${state_file}
+      echo "unknown" > ${state_file}
     fi
 
 {{- if .Values.solace.redundancy }}


### PR DESCRIPTION
Ensure PubSub+ HA state is pushed on first run of readiness_check.  Now "true" and "false" will equally be pushed.