### PR TITLE
DATAGO-112033: Support for new scaling parameters with validaion

### DIFF
--- a/pubsubplus/templates/solaceConfigMap.yaml
+++ b/pubsubplus/templates/solaceConfigMap.yaml
@@ -24,6 +24,21 @@ data:
     export system_scaling_maxconnectioncount={{ required "A valid maxConnections required!" .Values.solace.systemScaling.maxConnections | quote }}
     export system_scaling_maxqueuemessagecount={{ required "A valid maxQueueMessages required!" .Values.solace.systemScaling.maxQueueMessages | quote }}
     export messagespool_maxspoolusage={{ required "A valid maxSpoolUsage required!" .Values.solace.systemScaling.maxSpoolUsage | quote }}
+{{- if hasKey .Values.solace.systemScaling "maxKafkaBridgeCount" }}
+    export system_scaling_maxkafkabridgecount={{ .Values.solace.systemScaling.maxKafkaBridgeCount | quote }}
+{{- end }}
+{{- if hasKey .Values.solace.systemScaling "maxKafkaBrokerConnectionCount" }}
+    export system_scaling_maxkafkabrokerconnectioncount={{ .Values.solace.systemScaling.maxKafkaBrokerConnectionCount | quote }}
+{{- end }}
+{{- if hasKey .Values.solace.systemScaling "maxBridgeCount" }}
+    export system_scaling_maxbridgecount={{ .Values.solace.systemScaling.maxBridgeCount | quote }}
+{{- end }}
+{{- if hasKey .Values.solace.systemScaling "maxSubscriptionCount" }}
+    export system_scaling_maxsubscriptioncount={{ .Values.solace.systemScaling.maxSubscriptionCount | quote }}
+{{- end }}
+{{- if hasKey .Values.solace.systemScaling "maxGuaranteedMessageSize" }}
+    export system_scaling_maxguaranteedmessagesize={{ .Values.solace.systemScaling.maxGuaranteedMessageSize | quote }}
+{{- end }}
 {{- else if eq .Values.solace.size "dev" }}
     export system_scaling_maxconnectioncount="100"
 {{- else if eq .Values.solace.size "prod1k" }}

--- a/pubsubplus/templates/solaceStatefulSet.yaml
+++ b/pubsubplus/templates/solaceStatefulSet.yaml
@@ -133,6 +133,28 @@ spec:
           value: {{ printf "%s/%s" ":/usr/share/zoneinfo" (default "UTC" .Values.solace.timezone) }}
         - name: UMASK
           value: "0022"
+{{- if .Values.solace.systemScaling }}
+{{- if hasKey .Values.solace.systemScaling "maxKafkaBridgeCount" }}
+        - name: SYSTEM_SCALING_MAXKAFKABRIDGECOUNT
+          value: {{ .Values.solace.systemScaling.maxKafkaBridgeCount | quote }}
+{{- end }}
+{{- if hasKey .Values.solace.systemScaling "maxKafkaBrokerConnectionCount" }}
+        - name: SYSTEM_SCALING_MAXKAFKABROKERCONNECTIONCOUNT
+          value: {{ .Values.solace.systemScaling.maxKafkaBrokerConnectionCount | quote }}
+{{- end }}
+{{- if hasKey .Values.solace.systemScaling "maxBridgeCount" }}
+        - name: SYSTEM_SCALING_MAXBRIDGECOUNT
+          value: {{ .Values.solace.systemScaling.maxBridgeCount | quote }}
+{{- end }}
+{{- if hasKey .Values.solace.systemScaling "maxSubscriptionCount" }}
+        - name: SYSTEM_SCALING_MAXSUBSCRIPTIONCOUNT
+          value: {{ .Values.solace.systemScaling.maxSubscriptionCount | quote }}
+{{- end }}
+{{- if hasKey .Values.solace.systemScaling "maxGuaranteedMessageSize" }}
+        - name: SYSTEM_SCALING_MAXGUARANTEEDMESSAGESIZE
+          value: {{ .Values.solace.systemScaling.maxGuaranteedMessageSize | quote }}
+{{- end }}
+{{- end }}
 {{- if .Values.solace.extraEnvVars }}
       {{- range $item := .Values.solace.extraEnvVars }}
         - name: {{ $item.name }}

--- a/pubsubplus/values.schema.json
+++ b/pubsubplus/values.schema.json
@@ -110,6 +110,44 @@
                 "podDisruptionBudgetForHA": {
                     "type": "boolean"
                 },
+                "systemScaling": {
+                    "type": "object",
+                    "properties": {
+                        "maxConnections": {
+                            "type": "integer",
+                            "description": "Maximum supported number of client connections"
+                        },
+                        "maxQueueMessages": {
+                            "type": "integer",
+                            "description": "Number of queue messages, in millions of messages"
+                        },
+                        "maxSpoolUsage": {
+                            "type": "integer",
+                            "description": "Maximum Spool Usage in MB"
+                        },
+                        "maxKafkaBridgeCount": {
+                            "type": "integer",
+                            "description": "Maximum number of Kafka bridges"
+                        },
+                        "maxKafkaBrokerConnectionCount": {
+                            "type": "integer",
+                            "description": "Maximum number of connections to Kafka brokers"
+                        },
+                        "maxBridgeCount": {
+                            "type": "integer",
+                            "description": "Maximum number of bridges"
+                        },
+                        "maxSubscriptionCount": {
+                            "type": "integer",
+                            "description": "Maximum number of subscriptions"
+                        },
+                        "maxGuaranteedMessageSize": {
+                            "type": "integer",
+                            "description": "Maximum guaranteed message size in MB"
+                        }
+                    },
+                    "required": ["maxConnections", "maxQueueMessages", "maxSpoolUsage"]
+                },
                 "size": {
                     "type": "string"
                 },

--- a/pubsubplus/values.yaml
+++ b/pubsubplus/values.yaml
@@ -35,6 +35,16 @@ solace:
   #   cpu: 2
   #   # memory: host Virtual Memory
   #   memory: 3410Mi
+  #   # maxKafkaBridgeCount: Maximum number of Kafka bridges
+  #   maxKafkaBridgeCount: 0
+  #   # maxKafkaBrokerConnectionCount: Maximum number of connections to Kafka brokers
+  #   maxKafkaBrokerConnectionCount: 0
+  #   # maxBridgeCount: Maximum number of bridges
+  #   maxBridgeCount: 25
+  #   # maxSubscriptionCount: Maximum number of subscriptions
+  #   maxSubscriptionCount: 50000
+  #   # maxGuaranteedMessageSize: Maximum guaranteed message size in MB
+  #   maxGuaranteedMessageSize: 10
 
   # solace.podModifierEnabled=true enables modifying (reducing) CPU and memory resources for Monitoring nodes in an HA deployment
   # this must be provided and set to true to enable adjustments by the solace-pod-modifier admission plugin


### PR DESCRIPTION
### User description

#### Jira Link: 
- https://sol-jira.atlassian.net/browse/DATAGO-112032
- https://sol-jira.atlassian.net/browse/DATAGO-112033

### What is the purpose of this change?

Broker deployment now supports setting new scaling parameters. 

- `SYSTEM_SCALING_MAXKAFKABRIDGECOUNT`
- `SYSTEM_SCALING_MAXKAFKABROKERCONNECTIONCOUNT`
- `SYSTEM_SCALING_MAXBRIDGECOUNT`
- `SYSTEM_SCALING_MAXSUBSCRIPTIONCOUNT`
- `SYSTEM_SCALING_MAXGUARANTEEDMESSAGESIZE`

Support for new scaling parameters with validation. 

### Anything reviews should focus on/be aware of?

N/A



<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add support for five new Solace PubSub+ scaling parameters with proper validation in Helm charts.

Main changes:
- Added new optional scaling parameters with conditional exports in solaceConfigMap.yaml and solaceStatefulSet.yaml
- Updated values.schema.json with parameter definitions, types, descriptions, and validation requirements
- Added commented examples of new parameters in values.yaml for user reference

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
