### PR TITLE
DATAGO-112034: Documentation for new scaling parameter support

### DIFF
--- a/docs/PubSubPlusK8SDeployment.md
+++ b/docs/PubSubPlusK8SDeployment.md
@@ -149,7 +149,7 @@ Additionally, CPU and memory must be sized and provided in `solace.systemScaling
 > Note: beyond CPU and memory requirements, required storage size (see next section) also depends significantly on scaling. We recommend using the minimum required values specified in the [Resource Calculator](https://docs.solace.com/Configuring-and-Managing/SW-Broker-Specific-Config/System-Resource-Calculator.htm).
 > However, you can adjust these values in the YAML file based on your available resources. If you decide to allocate fewer resources than the recommended minimum, make sure to thoroughly test your deployment to ensure stability and performance.
 
-Also note, that specifying the scaling parameters on initial deployment will overwrite the broker’s default values. On the other hand, doing the same using Helm upgrade on an existing deployment will not overwrite these values on brokers configuration, but it can be used to prepare (first step) for a manual scale up through CLI where these parameters can be actually changed (second step).
+Also note that specifying the scaling parameters on initial deployment will overwrite the broker's default values. On the other hand, doing the same using Helm upgrade on an existing deployment will not overwrite these values on brokers configuration, but it can be used to prepare (first step) for a manual scale up through CLI where these parameters can be actually changed (second step).
 
 #### Enabling a Disruption Budget for HA deployment
 

--- a/docs/PubSubPlusK8SDeployment.md
+++ b/docs/PubSubPlusK8SDeployment.md
@@ -137,13 +137,19 @@ This option overrides simplified vertical scaling. It enables specifying each su
 * "maxConnections", in `solace.systemScaling.maxConnections` parameter
 * "maxQueueMessages", in `solace.systemScaling.maxQueueMessages` parameter
 * "maxSpoolUsage", in `solace.systemScaling.maxSpoolUsage` parameter
+* "maxKafkaBridgeCount", in `solace.systemScaling.maxKafkaBridgeCount` parameter
+* "maxKafkaBrokerConnectionCount", in `solace.systemScaling.maxKafkaBrokerConnectionCount` parameter
+* "maxBridgeCount", in `solace.systemScaling.maxBridgeCount` parameter
+* "maxSubscriptionCount", in `solace.systemScaling.maxSubscriptionCount` parameter
+* "maxGuaranteedMessageSize", in `solace.systemScaling.maxGuaranteedMessageSize` parameter
+
 
 Additionally, CPU and memory must be sized and provided in `solace.systemScaling.cpu` and `solace.systemScaling.memory` parameters. Use the [Solace online System Resource Calculator](https://docs.solace.com/Configuring-and-Managing/SW-Broker-Specific-Config/System-Resource-Calculator.htm) to determine CPU and memory requirements for the selected scaling parameters.
 
 > Note: beyond CPU and memory requirements, required storage size (see next section) also depends significantly on scaling. We recommend using the minimum required values specified in the [Resource Calculator](https://docs.solace.com/Configuring-and-Managing/SW-Broker-Specific-Config/System-Resource-Calculator.htm).
 > However, you can adjust these values in the YAML file based on your available resources. If you decide to allocate fewer resources than the recommended minimum, make sure to thoroughly test your deployment to ensure stability and performance.
 
-Also note, that specifying maxConnections, maxQueueMessages and maxSpoolUsage on initial deployment will overwrite the broker’s default values. On the other hand, doing the same using Helm upgrade on an existing deployment will not overwrite these values on brokers configuration, but it can be used to prepare (first step) for a manual scale up through CLI where these parameters can be actually changed (second step).
+Also note, that specifying the scaling parameters on initial deployment will overwrite the broker’s default values. On the other hand, doing the same using Helm upgrade on an existing deployment will not overwrite these values on brokers configuration, but it can be used to prepare (first step) for a manual scale up through CLI where these parameters can be actually changed (second step).
 
 #### Enabling a Disruption Budget for HA deployment
 

--- a/docs/PubSubPlusK8SDeployment.md
+++ b/docs/PubSubPlusK8SDeployment.md
@@ -149,7 +149,7 @@ Additionally, CPU and memory must be sized and provided in `solace.systemScaling
 > Note: beyond CPU and memory requirements, required storage size (see next section) also depends significantly on scaling. We recommend using the minimum required values specified in the [Resource Calculator](https://docs.solace.com/Configuring-and-Managing/SW-Broker-Specific-Config/System-Resource-Calculator.htm).
 > However, you can adjust these values in the YAML file based on your available resources. If you decide to allocate fewer resources than the recommended minimum, make sure to thoroughly test your deployment to ensure stability and performance.
 
-Also note that specifying the scaling parameters on initial deployment will overwrite the broker's default values. On the other hand, doing the same using Helm upgrade on an existing deployment will not overwrite these values on brokers configuration, but it can be used to prepare (first step) for a manual scale up through CLI where these parameters can be actually changed (second step).
+Also note, that specifying the scaling parameters on initial deployment will overwrite the broker’s default values. On the other hand, doing the same using Helm upgrade on an existing deployment will not overwrite these values on brokers configuration, but it can be used to prepare (first step) for a manual scale up through CLI where these parameters can be actually changed (second step).
 
 #### Enabling a Disruption Budget for HA deployment
 

--- a/docs/PubSubPlusK8SDeployment.md
+++ b/docs/PubSubPlusK8SDeployment.md
@@ -149,7 +149,7 @@ Additionally, CPU and memory must be sized and provided in `solace.systemScaling
 > Note: beyond CPU and memory requirements, required storage size (see next section) also depends significantly on scaling. We recommend using the minimum required values specified in the [Resource Calculator](https://docs.solace.com/Configuring-and-Managing/SW-Broker-Specific-Config/System-Resource-Calculator.htm).
 > However, you can adjust these values in the YAML file based on your available resources. If you decide to allocate fewer resources than the recommended minimum, make sure to thoroughly test your deployment to ensure stability and performance.
 
-Also note, that specifying the scaling parameters on initial deployment will overwrite the broker’s default values. On the other hand, doing the same using Helm upgrade on an existing deployment will not overwrite these values on brokers configuration, but it can be used to prepare (first step) for a manual scale up through CLI where these parameters can be actually changed (second step).
+Note that specifying the scaling parameters on initial deployment overwrites the broker’s default values. Using a Helm upgrade on an existing deployment avoids overwriting broker configuration values. You can use a Helm upgrade to prepare for a manual scale up using the CLI, where you can change the parameters.
 
 #### Enabling a Disruption Budget for HA deployment
 


### PR DESCRIPTION
### User description

#### Jira Link: 
- https://sol-jira.atlassian.net/browse/DATAGO-112034

### What is the purpose of this change?

Broker deployment now supports setting new scaling parameters. 

- `SYSTEM_SCALING_MAXKAFKABRIDGECOUNT`
- `SYSTEM_SCALING_MAXKAFKABROKERCONNECTIONCOUNT`
- `SYSTEM_SCALING_MAXBRIDGECOUNT`
- `SYSTEM_SCALING_MAXSUBSCRIPTIONCOUNT`
- `SYSTEM_SCALING_MAXGUARANTEEDMESSAGESIZE`

Support for new scaling parameters with validation. 

### Anything reviews should focus on/be aware of?

N/A



<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update PubSubPlusK8SDeployment documentation to include five new scaling parameters for Solace PubSub+ deployment in Kubernetes.

Main changes:
- Added documentation for five new scaling parameters including maxKafkaBridgeCount and maxSubscriptionCount
- Generalized the note about parameter behavior during initial deployment vs. Helm upgrades
- Improved clarity regarding when scaling parameters take effect on broker configuration

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
