### PR TITLE
DATAGO-134167: Native Insights Agent Pro (third-party forwarding) support

### DIFF
--- a/pubsubplus/Chart.yaml
+++ b/pubsubplus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Deploy Solace Event Broker Singleton or HA redundancy group onto a Kubernetes Cluster
 name: pubsubplus
-version: 3.9.0
+version: 3.10.0
 icon: https://solaceproducts.github.io/pubsubplus-kubernetes-helm-quickstart/images/solace.png
 kubeVersion: '>= 1.10.0-0'
 maintainers:

--- a/pubsubplus/INSIGHTS.md
+++ b/pubsubplus/INSIGHTS.md
@@ -12,8 +12,8 @@ For reference, see `pubsubplus/values.yaml` from [values.yaml](values.yaml).
 |-----------------------------------------------|-----------------------------------------------------------------------------------------------------|----------------------------------------------|
 | `enabled`                                     | Should be set to `true` if you want Insights enabled on the broker.                                 | `false`                                      |
 | `environmentVariables`                        | Environment variables for configuring the Insights Agent                                            |                                              |
-| `environmentVariables.INSIGHTS_AGENT_API_KEY` | The API key for your Solace Insights subscription. Available from the Solace Cloud Console.         |                                              |
-| `environmentVariables.INSIGHTS_AGENT_SITE`    | The site location where broker metrics and logs will flow. Available from the Solace Cloud Console. |                                              |
+| `environmentVariables.INSIGHTS_AGENT_API_KEY` | The API key for your Solace Insights subscription. Available from the Solace Cloud Console. Required in standard mode; optional when `forwarding.enabled=true`. |                                              |
+| `environmentVariables.INSIGHTS_AGENT_SITE`    | The site location where broker metrics and logs will flow. Available from the Solace Cloud Console. Required in standard mode; optional when `forwarding.enabled=true`. |                                              |
 | `environmentVariables.INSIGHTS_AGENT_TAGS`    | Tags for metrics and logs. Available from the Solace Cloud Console.                                 |                                              |
 | `image.repository`                            | The image repository for the Insights Agent container                                               | `gcr.io/gcp-maas-prod/solace-insights-agent` |
 | `image.tag`                                   | The image tag for the Insights Agent container                                                      | `latest`                                     |
@@ -64,8 +64,7 @@ To tune the collector's memory, set `INSIGHTS_AGENT_GOMEMLIMIT` (e.g. `"410MiB"`
 insights:
   enabled: true
   environmentVariables:
-    INSIGHTS_AGENT_API_KEY: "unused"
-    INSIGHTS_AGENT_SITE: "datadoghq.com"
+    # INSIGHTS_AGENT_API_KEY and INSIGHTS_AGENT_SITE are not required in forwarding mode.
     INSIGHTS_AGENT_TAGS: "<your-tags>"
   forwarding:
     enabled: true
@@ -91,8 +90,7 @@ Substitute your Datadog site for `<site>` (e.g. `datadoghq.com`) and your real A
 insights:
   enabled: true
   environmentVariables:
-    INSIGHTS_AGENT_API_KEY: "unused"
-    INSIGHTS_AGENT_SITE: "datadoghq.com"
+    # INSIGHTS_AGENT_API_KEY and INSIGHTS_AGENT_SITE are not required in forwarding mode.
     INSIGHTS_AGENT_TAGS: "<your-tags>"
     # ── dual-write to Datadog SaaS (passed through to the agent verbatim) ──
     INSIGHTS_AGENT_LOGS_ENABLED: "true"
@@ -118,8 +116,7 @@ effect when `forwarding.enabled=true`.
 insights:
   enabled: true
   environmentVariables:
-    INSIGHTS_AGENT_API_KEY: "unused"
-    INSIGHTS_AGENT_SITE: "datadoghq.com"
+    # INSIGHTS_AGENT_API_KEY and INSIGHTS_AGENT_SITE are not required in forwarding mode.
     INSIGHTS_AGENT_TAGS: "<your-tags>"
   forwarding:
     enabled: true

--- a/pubsubplus/INSIGHTS.md
+++ b/pubsubplus/INSIGHTS.md
@@ -24,8 +24,11 @@ For reference, see `pubsubplus/values.yaml` from [values.yaml](values.yaml).
 | `resources.limits.cpu`                        | Max CPU for the `insights-agent` container. Used verbatim if set; otherwise computed as the requests CPU plus a per-`solace.size` OTel headroom. | computed       |
 | `resources.limits.memory`                     | Max memory for the `insights-agent` container. Used verbatim if set; otherwise computed as the requests memory plus a per-`solace.size` OTel headroom. | computed   |
 | `forwarding.enabled`                          | Set `true` to enable Insights Agent Pro (third-party forwarding via the co-resident OTel collector). | `false`                                     |
-| `forwarding.otelConfig`                       | Inline `otel-config.yaml` content. Required when `forwarding.enabled=true`; rendered into a chart-managed Secret. | `""`                        |
-| `forwarding.logsConfig`                       | Inline `logs.yml` to override the agent's `/etc/datadog-agent/conf.d/solace.d/logs.yml` (rendered into a chart-managed ConfigMap). Only takes effect when `forwarding.enabled=true`. | `""`        |
+| `forwarding.otelConfig`                       | Inline `otel-config.yaml` content for all nodes. Required when `forwarding.enabled=true` unless per-node configs are set; rendered into a chart-managed Secret. | `""`        |
+| `forwarding.otelConfigPrimary`                | Per-node `otel-config.yaml` for the primary node (pod-0) in an HA deployment. Falls back to `forwarding.otelConfig` when empty. | `""`                       |
+| `forwarding.otelConfigBackup`                 | Per-node `otel-config.yaml` for the backup node (pod-1) in an HA deployment. Falls back to `forwarding.otelConfig` when empty. | `""`                        |
+| `forwarding.otelConfigMonitor`                | Per-node `otel-config.yaml` for the monitor node (pod-2) in an HA deployment. Falls back to `forwarding.otelConfig` when empty. | `""`                       |
+| `forwarding.logsConfig`                       | Inline `logs.yml` to override the agent's `/etc/datadog-agent/conf.d/solace.d/logs.yml` (rendered into a chart-managed ConfigMap, same for all nodes). Only takes effect when `forwarding.enabled=true`. | `""`        |
 
 ## Forwarding modes
 
@@ -129,3 +132,38 @@ insights:
           service: solace
           source: solace
 ```
+
+### HA deployments: per-node OTel config
+
+In an HA deployment (`solace.redundancy=true`) the broker runs three nodes — primary
+(pod-0), backup (pod-1), and monitor (pod-2). If each node needs a different
+`otel-config.yaml` (for example, an auto-generated config whose only per-node difference
+is the `ha_role` attribute), supply one config per node:
+
+- `forwarding.otelConfigPrimary` → pod-0
+- `forwarding.otelConfigBackup` → pod-1
+- `forwarding.otelConfigMonitor` → pod-2
+
+The chart renders them into a single Secret under per-index keys
+(`otel-config-0/1/2.yaml`) and each pod mounts its own via `subPathExpr` keyed on the
+pod index. A node with an empty per-node value falls back to `forwarding.otelConfig`, so
+you can also set just one or two of them. `logsConfig` is always shared across all nodes.
+
+Because these values are whole files, load them with `--set-file` instead of pasting
+(avoids indentation mistakes and keeps the generated files intact):
+
+```bash
+helm install my-release pubsubplus \
+  -f values.yaml \
+  --set solace.redundancy=true \
+  --set insights.enabled=true \
+  --set-file insights.forwarding.otelConfigPrimary=./otel-primary.yaml \
+  --set-file insights.forwarding.otelConfigBackup=./otel-backup.yaml \
+  --set-file insights.forwarding.otelConfigMonitor=./otel-monitor.yaml \
+  --set-file insights.forwarding.logsConfig=./logs.yaml
+```
+
+Keep the stable settings (`forwarding.enabled: true`, `environmentVariables`, image, etc.)
+in `values.yaml`; `--set-file` overrides the matching keys with each file's contents.
+(`--set-file` also works for the single-config keys, e.g.
+`--set-file insights.forwarding.otelConfig=./otel-config.yaml` in non-HA deployments.)

--- a/pubsubplus/INSIGHTS.md
+++ b/pubsubplus/INSIGHTS.md
@@ -21,14 +21,37 @@ For reference, see `pubsubplus/values.yaml` from [values.yaml](values.yaml).
 | `image.pullPolicy`                            | Image pull policy for the Insights Agent container (`Always`, `IfNotPresent`, `Never`). Set to `IfNotPresent`/`Never` for air-gapped clusters with pre-loaded images. | `Always`            |
 | `resources.requests.cpu`                      | The minimum CPU resource required by the `insights-agent` container.                                | `200m`                                       |
 | `resources.requests.memory`                   | The minimum memory resource required by the `insights-agent` container (must use `Mi`/`Gi` units).  | `256Mi`                                      |
-| `resources.limits.cpu`                        | Max CPU for the `insights-agent` container. Used verbatim if set; otherwise computed as the requests CPU plus a per-`solace.size` OTel headroom. | computed       |
-| `resources.limits.memory`                     | Max memory for the `insights-agent` container. Used verbatim if set; otherwise computed as the requests memory plus a per-`solace.size` OTel headroom. | computed   |
+| `resources.limits.cpu`                        | Max CPU for the `insights-agent` container. Used verbatim if set; otherwise computed as a fixed `200m` base plus a per-`solace.size` OTel headroom (raised to `requests.cpu` if that is higher). | computed       |
+| `resources.limits.memory`                     | Max memory for the `insights-agent` container. Used verbatim if set; otherwise computed as a fixed `256Mi` base plus a per-`solace.size` OTel headroom (raised to `requests.memory` if that is higher). | computed   |
 | `forwarding.enabled`                          | Set `true` to enable Insights Agent Pro (third-party forwarding via the co-resident OTel collector). | `false`                                     |
 | `forwarding.otelConfig`                       | Inline `otel-config.yaml` content for all nodes. Required when `forwarding.enabled=true` unless per-node configs are set; rendered into a chart-managed Secret. | `""`        |
 | `forwarding.otelConfigPrimary`                | Per-node `otel-config.yaml` for the primary node (pod-0) in an HA deployment. Falls back to `forwarding.otelConfig` when empty. | `""`                       |
 | `forwarding.otelConfigBackup`                 | Per-node `otel-config.yaml` for the backup node (pod-1) in an HA deployment. Falls back to `forwarding.otelConfig` when empty. | `""`                        |
 | `forwarding.otelConfigMonitor`                | Per-node `otel-config.yaml` for the monitor node (pod-2) in an HA deployment. Falls back to `forwarding.otelConfig` when empty. | `""`                       |
 | `forwarding.logsConfig`                       | Inline `logs.yml` to override the agent's `/etc/datadog-agent/conf.d/solace.d/logs.yml` (rendered into a chart-managed ConfigMap, same for all nodes). Only takes effect when `forwarding.enabled=true`. | `""`        |
+
+## Resource limits per broker size
+
+When `resources.limits` are not set, the chart computes them as a **fixed agent base**
+(`256Mi` / `200m`) plus a per-`solace.size` headroom for the co-resident OTel collector. The
+base is fixed (independent of `requests`), so these are stable per-size values — and the
+recommended **minimums** if you choose to set `resources.limits` explicitly:
+
+| `solace.size` | `resources.limits.memory` | `resources.limits.cpu` | Derived `INSIGHTS_AGENT_GOMEMLIMIT` |
+|---------------|---------------------------|------------------------|-------------------------------------|
+| `dev`         | `768Mi`                   | `700m`                 | `409MiB`                            |
+| `prod1k`      | `1280Mi`                  | `700m`                 | `819MiB`                            |
+| `prod10k`     | `2304Mi`                  | `1200m`                | `1638MiB`                           |
+| `prod100k`    | `4352Mi`                  | `2200m`                | `3276MiB`                           |
+| `prod200k`    | `5888Mi`                  | `2200m`                | `4505MiB`                           |
+
+Notes:
+
+- The chart renders CPU in cores (e.g. `0.7`), which Kubernetes displays as `700m` — both are equivalent.
+- The computed limit does **not** track `resources.requests`: raising requests below the value above leaves the limit unchanged. If a request *exceeds* the computed limit, the limit is raised to the request so the manifest stays valid (`limit >= request`).
+- **Guaranteed QoS:** to run the agent with `requests == limits`, set `resources.requests` to the row above for your `solace.size` and leave `resources.limits` unset — the computed limit will equal your requests.
+- If you set `resources.limits` explicitly they are used **verbatim** and are **not** validated against these minimums; set them at or above the row for your `solace.size` so the OTel collector has enough memory in forwarding mode.
+- The `INSIGHTS_AGENT_GOMEMLIMIT` column applies only in forwarding mode and reflects the computed-limits case (80% of the memory headroom); see [Forwarding-only](#forwarding-only-via-otel-collector-no-datadog-saas-push).
 
 ## Forwarding modes
 
@@ -58,15 +81,16 @@ collector config inline with `forwarding.otelConfig` (rendered into a chart-mana
 
 The collector's Go memory limit (`INSIGHTS_AGENT_GOMEMLIMIT`) is set automatically in
 forwarding mode: the chart derives it as 80% of the agent memory headroom (the effective
-memory limit minus `resources.requests.memory`), i.e. 80% of the per-`solace.size` headroom
-when limits are computed, or 80% of `limits.memory - requests.memory` when limits are
-explicit. To override the derived value, set `INSIGHTS_AGENT_GOMEMLIMIT` (e.g. `"410MiB"`)
-under `environmentVariables`. If you set explicit `resources.limits.memory` that does not
-exceed `requests.memory`, the chart cannot derive a value and fails fast — set
-`INSIGHTS_AGENT_GOMEMLIMIT` explicitly or raise the limit.
+memory limit minus the fixed `256Mi` base), i.e. 80% of the per-`solace.size` headroom when
+limits are computed, or 80% of `limits.memory - 256Mi` when limits are explicit. Measuring
+from the fixed base (not `requests`) means `requests == limits` does not zero the headroom.
+To override the derived value, set `INSIGHTS_AGENT_GOMEMLIMIT` (e.g. `"410MiB"`) under
+`environmentVariables`. If you set an explicit `resources.limits.memory` at or below the
+`256Mi` base, the chart cannot derive a value and fails fast — set `INSIGHTS_AGENT_GOMEMLIMIT`
+explicitly or raise the limit.
 
 > **Note on resource limits and `solace.systemScaling`:** when `resources.limits` are not
-> set, the chart computes the `insights-agent` limits as the requests value plus a headroom
+> set, the chart computes the `insights-agent` limits as the fixed base plus a headroom
 > selected by `solace.size`. If you scale the broker with `solace.systemScaling` (which makes
 > the chart ignore `solace.size`), that headroom falls back to the `solace.size` default tier
 > and will not track your actual broker size — set `insights.resources.limits` explicitly to

--- a/pubsubplus/INSIGHTS.md
+++ b/pubsubplus/INSIGHTS.md
@@ -53,8 +53,15 @@ insights:
 
 Routes metrics and logs through the co-resident OpenTelemetry collector. Supply the
 collector config inline with `forwarding.otelConfig` (rendered into a chart-managed Secret).
-To tune the collector's memory, set `INSIGHTS_AGENT_GOMEMLIMIT` (e.g. `"410MiB"`) under
-`environmentVariables` — it is passed through and honored only in forwarding mode.
+
+The collector's Go memory limit (`INSIGHTS_AGENT_GOMEMLIMIT`) is set automatically in
+forwarding mode: the chart derives it as 80% of the agent memory headroom (the effective
+memory limit minus `resources.requests.memory`), i.e. 80% of the per-`solace.size` headroom
+when limits are computed, or 80% of `limits.memory - requests.memory` when limits are
+explicit. To override the derived value, set `INSIGHTS_AGENT_GOMEMLIMIT` (e.g. `"410MiB"`)
+under `environmentVariables`. If you set explicit `resources.limits.memory` that does not
+exceed `requests.memory`, the chart cannot derive a value and fails fast — set
+`INSIGHTS_AGENT_GOMEMLIMIT` explicitly or raise the limit.
 
 > **Note on resource limits and `solace.systemScaling`:** when `resources.limits` are not
 > set, the chart computes the `insights-agent` limits as the requests value plus a headroom

--- a/pubsubplus/INSIGHTS.md
+++ b/pubsubplus/INSIGHTS.md
@@ -34,7 +34,9 @@ For reference, see `pubsubplus/values.yaml` from [values.yaml](values.yaml).
 
 The chart natively supports the Insights forwarding modes. Each is a single
 `helm install -f values.yaml` — no out-of-band `kubectl create secret` or `kubectl patch`
-is required, and the configuration survives `helm upgrade`.
+is required, and the configuration survives `helm upgrade`. (Note: applying a *change* to
+`otelConfig`/`logsConfig` on a later upgrade needs an agent restart — see
+[Applying otelConfig / logsConfig changes after an upgrade](#applying-otelconfig--logsconfig-changes-after-an-upgrade).)
 
 ### Standard (direct to Datadog SaaS)
 
@@ -175,3 +177,40 @@ Keep the stable settings (`forwarding.enabled: true`, `environmentVariables`, im
 in `values.yaml`; `--set-file` overrides the matching keys with each file's contents.
 (`--set-file` also works for the single-config keys, e.g.
 `--set-file insights.forwarding.otelConfig=./otel-config.yaml` in non-HA deployments.)
+
+### Applying `otelConfig` / `logsConfig` changes after an upgrade
+
+`otelConfig` and `logsConfig` are mounted into the `insights-agent` container as single files
+via `subPath`/`subPathExpr`. Kubernetes does **not** live-update `subPath` mounts, and the
+chart does not roll the broker pods on a config-only change. So when a `helm upgrade` changes
+only `otelConfig` or `logsConfig`, the chart-managed Secret/ConfigMap is updated, but the
+**running agents keep using the old config** until their container restarts. The agent picks up
+the new config the next time the `insights-agent` container starts.
+
+> **Wait for propagation first.** After the `helm upgrade`, the kubelet needs a short interval
+> (up to ~1 minute) to sync the updated Secret/ConfigMap onto the node. Restart the container
+> *after* that interval — restarting too early can re-mount the old content.
+
+Choose one of these to apply the change:
+
+**Option A — restart only the agent (no broker restart).** Restart the `insights-agent`
+container in place; the broker container and the pod are left untouched (no HA failover). Run
+this on every broker pod (all three in an HA deployment):
+
+```bash
+kubectl exec <release>-pubsubplus-<ordinal> -c insights-agent -n <namespace> -- kill 1
+```
+
+The container restarts (its `restartCount` increments) within the same pod and re-mounts the
+updated config. Use this when you do not want the broker to restart.
+
+**Option B — recreate the pods (broker restarts too).** Roll the StatefulSet; each pod is
+recreated with a fresh volume, so the new config is guaranteed to take effect. In an HA
+deployment this is a rolling restart (one pod at a time, with the usual primary/backup
+failover):
+
+```bash
+kubectl rollout restart statefulset/<release>-pubsubplus -n <namespace>
+```
+
+Use this when a broker restart is acceptable.

--- a/pubsubplus/INSIGHTS.md
+++ b/pubsubplus/INSIGHTS.md
@@ -144,9 +144,10 @@ is the `ha_role` attribute), supply one config per node:
 - `forwarding.otelConfigBackup` → pod-1
 - `forwarding.otelConfigMonitor` → pod-2
 
-The chart renders them into a single Secret under per-index keys
-(`otel-config-0/1/2.yaml`) and each pod mounts its own via `subPathExpr` keyed on the
-pod index. A node with an empty per-node value falls back to `forwarding.otelConfig`, so
+The chart renders them into a single Secret under per-pod keys
+(`otel-config-<release>-pubsubplus-<ordinal>.yaml`) and each pod mounts its own via
+`subPathExpr` keyed on the pod name (`metadata.name`, available on all Kubernetes
+versions). A node with an empty per-node value falls back to `forwarding.otelConfig`, so
 you can also set just one or two of them. `logsConfig` is always shared across all nodes.
 
 Because these values are whole files, load them with `--set-file` instead of pasting

--- a/pubsubplus/INSIGHTS.md
+++ b/pubsubplus/INSIGHTS.md
@@ -18,7 +18,117 @@ For reference, see `pubsubplus/values.yaml` from [values.yaml](values.yaml).
 | `image.repository`                            | The image repository for the Insights Agent container                                               | `gcr.io/gcp-maas-prod/solace-insights-agent` |
 | `image.tag`                                   | The image tag for the Insights Agent container                                                      | `latest`                                     |
 | `image.pullSecretName`                        | The name of the image pull secret for the Insights Agent container                                  | `gcr-reg-secret`                             |
+| `image.pullPolicy`                            | Image pull policy for the Insights Agent container (`Always`, `IfNotPresent`, `Never`). Set to `IfNotPresent`/`Never` for air-gapped clusters with pre-loaded images. | `Always`            |
 | `resources.requests.cpu`                      | The minimum CPU resource required by the `insights-agent` container.                                | `200m`                                       |
-| `resources.requests.memory`                   | The minimum memory resource required by the `insights-agent` container.                             | `256Mi`                                      |
-| `resources.limits.cpu`                        | The maximum CPU resource the `insights-agent` container can use.                                    | `200m`                                       |
-| `resources.limits.memory`                     | The maximum memory resource the `insights-agent` container can use.                                 | `512Mi`                                      |
+| `resources.requests.memory`                   | The minimum memory resource required by the `insights-agent` container (must use `Mi`/`Gi` units).  | `256Mi`                                      |
+| `resources.limits.cpu`                        | Max CPU for the `insights-agent` container. Used verbatim if set; otherwise computed as the requests CPU plus a per-`solace.size` OTel headroom. | computed       |
+| `resources.limits.memory`                     | Max memory for the `insights-agent` container. Used verbatim if set; otherwise computed as the requests memory plus a per-`solace.size` OTel headroom. | computed   |
+| `forwarding.enabled`                          | Set `true` to enable Insights Agent Pro (third-party forwarding via the co-resident OTel collector). | `false`                                     |
+| `forwarding.otelConfig`                       | Inline `otel-config.yaml` content. Required when `forwarding.enabled=true`; rendered into a chart-managed Secret. | `""`                        |
+| `forwarding.logsConfig`                       | Inline `logs.yml` to override the agent's `/etc/datadog-agent/conf.d/solace.d/logs.yml` (rendered into a chart-managed ConfigMap). Only takes effect when `forwarding.enabled=true`. | `""`        |
+
+## Forwarding modes
+
+The chart natively supports the Insights forwarding modes. Each is a single
+`helm install -f values.yaml` — no out-of-band `kubectl create secret` or `kubectl patch`
+is required, and the configuration survives `helm upgrade`.
+
+### Standard (direct to Datadog SaaS)
+
+The default. The agent ships metrics and logs straight to Datadog SaaS.
+
+```yaml
+insights:
+  enabled: true
+  environmentVariables:
+    INSIGHTS_AGENT_API_KEY: "<your-api-key>"
+    INSIGHTS_AGENT_SITE: "datadoghq.com"
+    INSIGHTS_AGENT_TAGS: "<your-tags>"
+```
+
+### Forwarding-only (via OTel collector, no Datadog SaaS push)
+
+Routes metrics and logs through the co-resident OpenTelemetry collector. Supply the
+collector config inline with `forwarding.otelConfig` (rendered into a chart-managed Secret).
+To tune the collector's memory, set `INSIGHTS_AGENT_GOMEMLIMIT` (e.g. `"410MiB"`) under
+`environmentVariables` — it is passed through and honored only in forwarding mode.
+
+> **Note on resource limits and `solace.systemScaling`:** when `resources.limits` are not
+> set, the chart computes the `insights-agent` limits as the requests value plus a headroom
+> selected by `solace.size`. If you scale the broker with `solace.systemScaling` (which makes
+> the chart ignore `solace.size`), that headroom falls back to the `solace.size` default tier
+> and will not track your actual broker size — set `insights.resources.limits` explicitly to
+> size the agent for a custom-scaled broker.
+
+```yaml
+insights:
+  enabled: true
+  environmentVariables:
+    INSIGHTS_AGENT_API_KEY: "unused"
+    INSIGHTS_AGENT_SITE: "datadoghq.com"
+    INSIGHTS_AGENT_TAGS: "<your-tags>"
+  forwarding:
+    enabled: true
+    otelConfig: |
+      receivers:
+        datadog:
+          endpoint: localhost:6000
+      exporters:
+        # ...your exporters...
+      service:
+        pipelines:
+          # ...your pipelines...
+```
+
+### Forwarding + Datadog push (dual-write)
+
+Forwards through the OTel collector and also dual-writes to Datadog SaaS. Dual-write is
+not a separate chart setting — it is driven entirely by three agent env vars that you
+provide under `insights.environmentVariables`; the chart passes them through verbatim.
+Substitute your Datadog site for `<site>` (e.g. `datadoghq.com`) and your real API keys.
+
+```yaml
+insights:
+  enabled: true
+  environmentVariables:
+    INSIGHTS_AGENT_API_KEY: "unused"
+    INSIGHTS_AGENT_SITE: "datadoghq.com"
+    INSIGHTS_AGENT_TAGS: "<your-tags>"
+    # ── dual-write to Datadog SaaS (passed through to the agent verbatim) ──
+    INSIGHTS_AGENT_LOGS_ENABLED: "true"
+    INSIGHTS_AGENT_ADDITIONAL_ENDPOINTS: '{"https://app.datadoghq.com":["REAL_DD_KEY_1","REAL_DD_KEY_2"]}'
+    INSIGHTS_AGENT_LOGS_CONFIG_ADDITIONAL_ENDPOINTS: '[{"api_key":"REAL_DD_KEY_1","host":"agent-http-intake.logs.datadoghq.com","use_compression":true,"compression_level":2},{"api_key":"REAL_DD_KEY_2","host":"agent-http-intake.logs.datadoghq.com","use_compression":true,"compression_level":2}]'
+  forwarding:
+    enabled: true
+    otelConfig: |
+      receivers:
+        datadog:
+          endpoint: localhost:6000
+      # ...
+```
+
+### Overriding the agent log-collection config (`logs.yml`)
+
+In forwarding mode you can replace the Datadog agent's Solace log-collection config
+(`/etc/datadog-agent/conf.d/solace.d/logs.yml`). Supply it inline with `forwarding.logsConfig`
+(rendered into a chart-managed ConfigMap and mounted over that single file). This only takes
+effect when `forwarding.enabled=true`.
+
+```yaml
+insights:
+  enabled: true
+  environmentVariables:
+    INSIGHTS_AGENT_API_KEY: "unused"
+    INSIGHTS_AGENT_SITE: "datadoghq.com"
+    INSIGHTS_AGENT_TAGS: "<your-tags>"
+  forwarding:
+    enabled: true
+    otelConfig: |
+      service: {}
+    logsConfig: |
+      logs:
+        - type: file
+          path: /jail/logs/*.log
+          service: solace
+          source: solace
+```

--- a/pubsubplus/templates/NOTES.txt
+++ b/pubsubplus/templates/NOTES.txt
@@ -22,7 +22,7 @@ Pull Secret: {{ .Values.insights.image.pullSecretName }}
 {{- end }}
 
 Insights Agent is configured with the following:
-- Site: {{ .Values.insights.environmentVariables.INSIGHTS_AGENT_SITE }}
+- Site: {{ .Values.insights.environmentVariables.INSIGHTS_AGENT_SITE | default "(agent default)" }}
 - Tags: {{ .Values.insights.environmentVariables.INSIGHTS_AGENT_TAGS }}
 - Mode: {{ if .Values.insights.forwarding.enabled }}forwarding (Insights Agent Pro, via OTel collector){{ else }}standard (direct to Datadog SaaS){{ end }}
 {{- if .Values.insights.forwarding.enabled }}

--- a/pubsubplus/templates/NOTES.txt
+++ b/pubsubplus/templates/NOTES.txt
@@ -25,12 +25,6 @@ Insights Agent is configured with the following:
 - Site: {{ .Values.insights.environmentVariables.INSIGHTS_AGENT_SITE | default "datadoghq.com" }}
 - Tags: {{ .Values.insights.environmentVariables.INSIGHTS_AGENT_TAGS }}
 - Mode: {{ if .Values.insights.forwarding.enabled }}forwarding (Insights Agent Pro){{ else }}standard (direct to Datadog SaaS){{ end }}
-{{- if .Values.insights.forwarding.enabled }}
-- OTel config Secret: {{ template "solace.fullname" . }}-otel-config (chart-managed)
-{{- if .Values.insights.forwarding.logsConfig }}
-- Agent logs.yml override: {{ template "solace.fullname" . }}-logs-config (chart-managed ConfigMap)
-{{- end }}
-{{- end }}
 
 {{- else }}
 Solace Event Broker Insights has not been enabled for this deployment.

--- a/pubsubplus/templates/NOTES.txt
+++ b/pubsubplus/templates/NOTES.txt
@@ -22,9 +22,9 @@ Pull Secret: {{ .Values.insights.image.pullSecretName }}
 {{- end }}
 
 Insights Agent is configured with the following:
-- Site: {{ .Values.insights.environmentVariables.INSIGHTS_AGENT_SITE | default "(agent default)" }}
+- Site: {{ .Values.insights.environmentVariables.INSIGHTS_AGENT_SITE | default "datadoghq.com" }}
 - Tags: {{ .Values.insights.environmentVariables.INSIGHTS_AGENT_TAGS }}
-- Mode: {{ if .Values.insights.forwarding.enabled }}forwarding (Insights Agent Pro, via OTel collector){{ else }}standard (direct to Datadog SaaS){{ end }}
+- Mode: {{ if .Values.insights.forwarding.enabled }}forwarding (Insights Agent Pro){{ else }}standard (direct to Datadog SaaS){{ end }}
 {{- if .Values.insights.forwarding.enabled }}
 - OTel config Secret: {{ template "solace.fullname" . }}-otel-config (chart-managed)
 {{- if .Values.insights.forwarding.logsConfig }}

--- a/pubsubplus/templates/NOTES.txt
+++ b/pubsubplus/templates/NOTES.txt
@@ -24,6 +24,13 @@ Pull Secret: {{ .Values.insights.image.pullSecretName }}
 Insights Agent is configured with the following:
 - Site: {{ .Values.insights.environmentVariables.INSIGHTS_AGENT_SITE }}
 - Tags: {{ .Values.insights.environmentVariables.INSIGHTS_AGENT_TAGS }}
+- Mode: {{ if .Values.insights.forwarding.enabled }}forwarding (Insights Agent Pro, via OTel collector){{ else }}standard (direct to Datadog SaaS){{ end }}
+{{- if .Values.insights.forwarding.enabled }}
+- OTel config Secret: {{ template "solace.fullname" . }}-otel-config (chart-managed)
+{{- if .Values.insights.forwarding.logsConfig }}
+- Agent logs.yml override: {{ template "solace.fullname" . }}-logs-config (chart-managed ConfigMap)
+{{- end }}
+{{- end }}
 
 {{- else }}
 Solace Event Broker Insights has not been enabled for this deployment.

--- a/pubsubplus/templates/_helpers.tpl
+++ b/pubsubplus/templates/_helpers.tpl
@@ -38,3 +38,36 @@ Determine the service type based on redundancy
 {{- end -}}
 {{- $serviceType -}}
 {{- end -}}
+
+{{/*
+Computed insights-agent memory limit, used when insights.resources.limits.memory is not
+set: base + per-broker-size-class headroom (MiB) for the co-resident OTel collector.
+Base = insights.resources.requests.memory when set, otherwise 256Mi.
+*/}}
+{{- define "insights.agentLimitMemory" -}}
+{{- $deltas := dict "dev" 512 "prod1k" 1024 "prod10k" 2048 "prod100k" 4096 "prod200k" 5632 -}}
+{{- $delta := int (dig .Values.solace.size 0 $deltas) -}}
+{{- $requests := .Values.insights.resources.requests | default dict -}}
+{{- $base := $requests.memory | default "256Mi" | toString -}}
+{{- $baseMi := 0.0 -}}
+{{- if hasSuffix "Gi" $base -}}{{- $baseMi = mulf (trimSuffix "Gi" $base | float64) 1024.0 -}}
+{{- else if hasSuffix "Mi" $base -}}{{- $baseMi = trimSuffix "Mi" $base | float64 -}}
+{{- else -}}{{- fail (printf "insights.resources.requests.memory must be specified in Mi or Gi, got %q" $base) -}}{{- end -}}
+{{- printf "%dMi" (add (ceil $baseMi | int) $delta) -}}
+{{- end -}}
+
+{{/*
+Computed insights-agent CPU limit (in cores), used when insights.resources.limits.cpu is
+not set: base + per-broker-size-class headroom (millicores) for the co-resident OTel
+collector. Base = insights.resources.requests.cpu when set, otherwise 200m.
+*/}}
+{{- define "insights.agentLimitCpu" -}}
+{{- $deltas := dict "dev" 500 "prod1k" 500 "prod10k" 1000 "prod100k" 2000 "prod200k" 2000 -}}
+{{- $delta := int (dig .Values.solace.size 0 $deltas) -}}
+{{- $requests := .Values.insights.resources.requests | default dict -}}
+{{- $base := $requests.cpu | default "200m" | toString -}}
+{{- $baseM := 0.0 -}}
+{{- if hasSuffix "m" $base -}}{{- $baseM = trimSuffix "m" $base | float64 -}}
+{{- else -}}{{- $baseM = mulf ($base | float64) 1000.0 -}}{{- end -}}
+{{- divf (add (ceil $baseM | int) $delta) 1000 -}}
+{{- end -}}

--- a/pubsubplus/templates/_helpers.tpl
+++ b/pubsubplus/templates/_helpers.tpl
@@ -77,3 +77,36 @@ collector. Base = insights.resources.requests.cpu when set, otherwise 200m.
 {{- else -}}{{- $baseM = mulf ($base | float64) 1000.0 -}}{{- end -}}
 {{- divf (add (ceil $baseM | int) $delta) 1000 -}}
 {{- end -}}
+
+{{/*
+Parse a Kubernetes memory quantity (Mi or Gi) to an integer number of MiB.
+Usage: include "insights.memToMi" (dict "v" "512Mi")
+*/}}
+{{- define "insights.memToMi" -}}
+{{- $s := .v | toString -}}
+{{- if hasSuffix "Gi" $s -}}{{- mulf (trimSuffix "Gi" $s | float64) 1024.0 | int -}}
+{{- else if hasSuffix "Mi" $s -}}{{- trimSuffix "Mi" $s | float64 | int -}}
+{{- else -}}{{- fail (printf "insights memory values must be specified in Mi or Gi, got %q" $s) -}}{{- end -}}
+{{- end -}}
+
+{{/*
+INSIGHTS_AGENT_GOMEMLIMIT for the co-resident OTel collector (forwarding mode only),
+used when the operator has not set it explicitly. 80% of the memory headroom allotted to
+the collector: the effective agent memory limit minus the requests memory. The effective
+limit is insights.resources.limits.memory when set, otherwise the computed
+requests + per-solace.size headroom (so this reduces to 80% of that headroom).
+Fails if the headroom is not positive (explicit limit does not exceed requests).
+*/}}
+{{- define "insights.agentGomemLimit" -}}
+{{- $limits := .Values.insights.resources.limits | default dict -}}
+{{- $requests := .Values.insights.resources.requests | default dict -}}
+{{- $effLimit := "" -}}
+{{- if $limits.memory -}}{{- $effLimit = $limits.memory -}}{{- else -}}{{- $effLimit = (include "insights.agentLimitMemory" .) -}}{{- end -}}
+{{- $limMi := int (include "insights.memToMi" (dict "v" $effLimit)) -}}
+{{- $reqMi := int (include "insights.memToMi" (dict "v" ($requests.memory | default "256Mi"))) -}}
+{{- $headroom := sub $limMi $reqMi -}}
+{{- if le $headroom 0 -}}
+{{- fail "insights: cannot derive INSIGHTS_AGENT_GOMEMLIMIT because insights.resources.limits.memory does not exceed requests.memory; set INSIGHTS_AGENT_GOMEMLIMIT explicitly or raise the limit" -}}
+{{- end -}}
+{{- printf "%dMiB" (div (mul $headroom 80) 100) -}}
+{{- end -}}

--- a/pubsubplus/templates/_helpers.tpl
+++ b/pubsubplus/templates/_helpers.tpl
@@ -46,7 +46,10 @@ Base = insights.resources.requests.memory when set, otherwise 256Mi.
 */}}
 {{- define "insights.agentLimitMemory" -}}
 {{- $deltas := dict "dev" 512 "prod1k" 1024 "prod10k" 2048 "prod100k" 4096 "prod200k" 5632 -}}
-{{- $delta := int (dig .Values.solace.size 0 $deltas) -}}
+{{- if not (hasKey $deltas .Values.solace.size) -}}
+{{- fail (printf "insights: cannot compute the agent memory limit for unknown solace.size %q; set insights.resources.limits.memory explicitly" .Values.solace.size) -}}
+{{- end -}}
+{{- $delta := int (get $deltas .Values.solace.size) -}}
 {{- $requests := .Values.insights.resources.requests | default dict -}}
 {{- $base := $requests.memory | default "256Mi" | toString -}}
 {{- $baseMi := 0.0 -}}
@@ -63,7 +66,10 @@ collector. Base = insights.resources.requests.cpu when set, otherwise 200m.
 */}}
 {{- define "insights.agentLimitCpu" -}}
 {{- $deltas := dict "dev" 500 "prod1k" 500 "prod10k" 1000 "prod100k" 2000 "prod200k" 2000 -}}
-{{- $delta := int (dig .Values.solace.size 0 $deltas) -}}
+{{- if not (hasKey $deltas .Values.solace.size) -}}
+{{- fail (printf "insights: cannot compute the agent cpu limit for unknown solace.size %q; set insights.resources.limits.cpu explicitly" .Values.solace.size) -}}
+{{- end -}}
+{{- $delta := int (get $deltas .Values.solace.size) -}}
 {{- $requests := .Values.insights.resources.requests | default dict -}}
 {{- $base := $requests.cpu | default "200m" | toString -}}
 {{- $baseM := 0.0 -}}

--- a/pubsubplus/templates/_helpers.tpl
+++ b/pubsubplus/templates/_helpers.tpl
@@ -41,41 +41,45 @@ Determine the service type based on redundancy
 
 {{/*
 Computed insights-agent memory limit, used when insights.resources.limits.memory is not
-set: base + per-broker-size-class headroom (MiB) for the co-resident OTel collector.
-Base = insights.resources.requests.memory when set, otherwise 256Mi.
+set: a fixed agent base (256Mi) plus a per-broker-size-class headroom (MiB) for the
+co-resident OTel collector. The base is fixed (not the requests value) so the limit is a
+stable per-size value — this lets operators run Guaranteed QoS by setting requests equal to
+this value and leaving limits unset. If requests.memory exceeds base + headroom, the limit
+is raised to the request so the manifest stays valid (limit >= request).
 */}}
 {{- define "insights.agentLimitMemory" -}}
 {{- $deltas := dict "dev" 512 "prod1k" 1024 "prod10k" 2048 "prod100k" 4096 "prod200k" 5632 -}}
 {{- if not (hasKey $deltas .Values.solace.size) -}}
 {{- fail (printf "insights: cannot compute the agent memory limit for unknown solace.size %q; set insights.resources.limits.memory explicitly" .Values.solace.size) -}}
 {{- end -}}
-{{- $delta := int (get $deltas .Values.solace.size) -}}
+{{- $computed := add 256 (int (get $deltas .Values.solace.size)) -}}
 {{- $requests := .Values.insights.resources.requests | default dict -}}
-{{- $base := $requests.memory | default "256Mi" | toString -}}
-{{- $baseMi := 0.0 -}}
-{{- if hasSuffix "Gi" $base -}}{{- $baseMi = mulf (trimSuffix "Gi" $base | float64) 1024.0 -}}
-{{- else if hasSuffix "Mi" $base -}}{{- $baseMi = trimSuffix "Mi" $base | float64 -}}
-{{- else -}}{{- fail (printf "insights.resources.requests.memory must be specified in Mi or Gi, got %q" $base) -}}{{- end -}}
-{{- printf "%dMi" (add (ceil $baseMi | int) $delta) -}}
+{{- $req := $requests.memory | default "256Mi" | toString -}}
+{{- $reqMi := 0.0 -}}
+{{- if hasSuffix "Gi" $req -}}{{- $reqMi = mulf (trimSuffix "Gi" $req | float64) 1024.0 -}}
+{{- else if hasSuffix "Mi" $req -}}{{- $reqMi = trimSuffix "Mi" $req | float64 -}}
+{{- else -}}{{- fail (printf "insights.resources.requests.memory must be specified in Mi or Gi, got %q" $req) -}}{{- end -}}
+{{- printf "%dMi" (max (ceil $reqMi | int) $computed) -}}
 {{- end -}}
 
 {{/*
 Computed insights-agent CPU limit (in cores), used when insights.resources.limits.cpu is
-not set: base + per-broker-size-class headroom (millicores) for the co-resident OTel
-collector. Base = insights.resources.requests.cpu when set, otherwise 200m.
+not set: a fixed agent base (200m) plus a per-broker-size-class headroom (millicores) for
+the co-resident OTel collector. The base is fixed (not the requests value); if requests.cpu
+exceeds base + headroom, the limit is raised to the request (limit >= request).
 */}}
 {{- define "insights.agentLimitCpu" -}}
 {{- $deltas := dict "dev" 500 "prod1k" 500 "prod10k" 1000 "prod100k" 2000 "prod200k" 2000 -}}
 {{- if not (hasKey $deltas .Values.solace.size) -}}
 {{- fail (printf "insights: cannot compute the agent cpu limit for unknown solace.size %q; set insights.resources.limits.cpu explicitly" .Values.solace.size) -}}
 {{- end -}}
-{{- $delta := int (get $deltas .Values.solace.size) -}}
+{{- $computed := add 200 (int (get $deltas .Values.solace.size)) -}}
 {{- $requests := .Values.insights.resources.requests | default dict -}}
-{{- $base := $requests.cpu | default "200m" | toString -}}
-{{- $baseM := 0.0 -}}
-{{- if hasSuffix "m" $base -}}{{- $baseM = trimSuffix "m" $base | float64 -}}
-{{- else -}}{{- $baseM = mulf ($base | float64) 1000.0 -}}{{- end -}}
-{{- divf (add (ceil $baseM | int) $delta) 1000 -}}
+{{- $req := $requests.cpu | default "200m" | toString -}}
+{{- $reqM := 0.0 -}}
+{{- if hasSuffix "m" $req -}}{{- $reqM = trimSuffix "m" $req | float64 -}}
+{{- else -}}{{- $reqM = mulf ($req | float64) 1000.0 -}}{{- end -}}
+{{- divf (max (ceil $reqM | int) $computed) 1000 -}}
 {{- end -}}
 
 {{/*
@@ -92,21 +96,20 @@ Usage: include "insights.memToMi" (dict "v" "512Mi")
 {{/*
 INSIGHTS_AGENT_GOMEMLIMIT for the co-resident OTel collector (forwarding mode only),
 used when the operator has not set it explicitly. 80% of the memory headroom allotted to
-the collector: the effective agent memory limit minus the requests memory. The effective
-limit is insights.resources.limits.memory when set, otherwise the computed
-requests + per-solace.size headroom (so this reduces to 80% of that headroom).
-Fails if the headroom is not positive (explicit limit does not exceed requests).
+the collector: the effective agent memory limit minus the fixed agent base (256Mi). The
+effective limit is insights.resources.limits.memory when set, otherwise the computed limit
+(base + per-solace.size headroom), so this reduces to 80% of that headroom. It is measured
+from the fixed base (not requests) so setting requests == limits does not zero the headroom.
+Fails if the effective limit is at or below the base.
 */}}
 {{- define "insights.agentGomemLimit" -}}
 {{- $limits := .Values.insights.resources.limits | default dict -}}
-{{- $requests := .Values.insights.resources.requests | default dict -}}
 {{- $effLimit := "" -}}
 {{- if $limits.memory -}}{{- $effLimit = $limits.memory -}}{{- else -}}{{- $effLimit = (include "insights.agentLimitMemory" .) -}}{{- end -}}
 {{- $limMi := int (include "insights.memToMi" (dict "v" $effLimit)) -}}
-{{- $reqMi := int (include "insights.memToMi" (dict "v" ($requests.memory | default "256Mi"))) -}}
-{{- $headroom := sub $limMi $reqMi -}}
+{{- $headroom := sub $limMi 256 -}}
 {{- if le $headroom 0 -}}
-{{- fail "insights: cannot derive INSIGHTS_AGENT_GOMEMLIMIT because insights.resources.limits.memory does not exceed requests.memory; set INSIGHTS_AGENT_GOMEMLIMIT explicitly or raise the limit" -}}
+{{- fail "insights: cannot derive INSIGHTS_AGENT_GOMEMLIMIT because insights.resources.limits.memory is at or below the agent base (256Mi); set INSIGHTS_AGENT_GOMEMLIMIT explicitly or raise the limit" -}}
 {{- end -}}
 {{- printf "%dMiB" (div (mul $headroom 80) 100) -}}
 {{- end -}}

--- a/pubsubplus/templates/insights-agent-secret.yaml
+++ b/pubsubplus/templates/insights-agent-secret.yaml
@@ -84,8 +84,18 @@ metadata:
   name: {{ template "solace.fullname" . }}-insights-agent-env-secrets
 type: Opaque
 data:
+  {{- /* Keys the chart manages in the stringData block below. Exclude them from the
+         operator-supplied environmentVariables loop so they are not emitted in both
+         data and stringData with conflicting server-side merge precedence.
+         Keep this list in sync with the stringData keys. */ -}}
+  {{- $managedKeys := list "INSIGHTS_AGENT_BROKER_HOSTNAME" "INSIGHTS_AGENT_SEMP_USERNAME" "INSIGHTS_AGENT_SEMP_PASSWORD" "INSIGHTS_AGENT_SEMP_PORT" "INSIGHTS_AGENT_SEMP_PROTOCOL" "INSIGHTS_AGENT_HEALTH_CHECK_PORT" }}
+  {{- if .Values.insights.forwarding.enabled }}
+  {{- $managedKeys = concat $managedKeys (list "SOLACE_CUSTOM_INSIGHTS_ENABLED" "INSIGHTS_AGENT_TELEMETRY_ENABLED") }}
+  {{- end }}
   {{- range $key, $value := .Values.insights.environmentVariables }}
+  {{- if not (has $key $managedKeys) }}
   {{ $key }}: {{ $value | b64enc | quote }}
+  {{- end }}
   {{- end }}
 stringData:
   INSIGHTS_AGENT_BROKER_HOSTNAME: "localhost"

--- a/pubsubplus/templates/insights-agent-secret.yaml
+++ b/pubsubplus/templates/insights-agent-secret.yaml
@@ -107,5 +107,11 @@ stringData:
 {{- if .Values.insights.forwarding.enabled }}
   SOLACE_CUSTOM_INSIGHTS_ENABLED: "true"
   INSIGHTS_AGENT_TELEMETRY_ENABLED: "false"
+  {{- /* Derive GOMEMLIMIT for the OTel collector from the agent memory headroom when the
+         operator has not set it. If they set it under environmentVariables it passes
+         through the data block above, so we must not emit it here too. */ -}}
+  {{- if not .Values.insights.environmentVariables.INSIGHTS_AGENT_GOMEMLIMIT }}
+  INSIGHTS_AGENT_GOMEMLIMIT: {{ include "insights.agentGomemLimit" . | quote }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/pubsubplus/templates/insights-agent-secret.yaml
+++ b/pubsubplus/templates/insights-agent-secret.yaml
@@ -28,11 +28,17 @@ http
 {{- if not .Values.insights.environmentVariables }}
 {{- fail "insights.environmentVariables must be defined when Insights is enabled" }}
 {{- end }}
+{{- /* INSIGHTS_AGENT_API_KEY / INSIGHTS_AGENT_SITE are only required in standard mode.
+       In forwarding mode the agent does not use them (custom-entrypoint.sh overrides
+       DD_API_KEY, and DD_SITE falls back to the agent default when left empty), so
+       they are optional there. */ -}}
+{{- if not .Values.insights.forwarding.enabled }}
 {{- if not .Values.insights.environmentVariables.INSIGHTS_AGENT_API_KEY }}
 {{- fail "insights.environmentVariables.INSIGHTS_AGENT_API_KEY must be defined when Insights is enabled" }}
 {{- end }}
 {{- if not .Values.insights.environmentVariables.INSIGHTS_AGENT_SITE }}
 {{- fail "insights.environmentVariables.INSIGHTS_AGENT_SITE must be defined when Insights is enabled" }}
+{{- end }}
 {{- end }}
 {{- if not .Values.insights.environmentVariables.INSIGHTS_AGENT_TAGS }}
 {{- fail "insights.environmentVariables.INSIGHTS_AGENT_TAGS must be defined when Insights is enabled" }}

--- a/pubsubplus/templates/insights-agent-secret.yaml
+++ b/pubsubplus/templates/insights-agent-secret.yaml
@@ -49,8 +49,17 @@ http
 {{- end }}
 
 {{- if .Values.insights.forwarding.enabled }}
-{{- if not .Values.insights.forwarding.otelConfig }}
-{{- fail "insights.forwarding.enabled=true requires insights.forwarding.otelConfig" }}
+{{- $f := .Values.insights.forwarding }}
+{{- if not (or $f.otelConfig $f.otelConfigPrimary) }}
+{{- fail "insights.forwarding.enabled=true requires insights.forwarding.otelConfig (or insights.forwarding.otelConfigPrimary)" }}
+{{- end }}
+{{- if .Values.solace.redundancy }}
+{{- if not (or $f.otelConfig $f.otelConfigBackup) }}
+{{- fail "HA (solace.redundancy=true) requires insights.forwarding.otelConfigBackup or insights.forwarding.otelConfig for the backup node" }}
+{{- end }}
+{{- if not (or $f.otelConfig $f.otelConfigMonitor) }}
+{{- fail "HA (solace.redundancy=true) requires insights.forwarding.otelConfigMonitor or insights.forwarding.otelConfig for the monitor node" }}
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/pubsubplus/templates/insights-agent-secret.yaml
+++ b/pubsubplus/templates/insights-agent-secret.yaml
@@ -38,6 +38,16 @@ http
 {{- fail "insights.environmentVariables.INSIGHTS_AGENT_TAGS must be defined when Insights is enabled" }}
 {{- end }}
 
+{{- if and .Values.insights.forwarding.logsConfig (not .Values.insights.forwarding.enabled) }}
+{{- fail "insights.forwarding.logsConfig only takes effect when insights.forwarding.enabled=true" }}
+{{- end }}
+
+{{- if .Values.insights.forwarding.enabled }}
+{{- if not .Values.insights.forwarding.otelConfig }}
+{{- fail "insights.forwarding.enabled=true requires insights.forwarding.otelConfig" }}
+{{- end }}
+{{- end }}
+
 {{- $insightsPasswordValue := include "insightsAgent.password" . -}}
 ---
 apiVersion: v1
@@ -69,4 +79,8 @@ stringData:
   INSIGHTS_AGENT_SEMP_PORT: "{{ template "insightsAgent.sempPort" . }}"
   INSIGHTS_AGENT_SEMP_PROTOCOL: {{ template "insightsAgent.sempProtocol" . }}
   INSIGHTS_AGENT_HEALTH_CHECK_PORT: "5550"
+{{- if .Values.insights.forwarding.enabled }}
+  SOLACE_CUSTOM_INSIGHTS_ENABLED: "true"
+  INSIGHTS_AGENT_TELEMETRY_ENABLED: "false"
+{{- end }}
 {{- end }}

--- a/pubsubplus/templates/insights-agent-secret.yaml
+++ b/pubsubplus/templates/insights-agent-secret.yaml
@@ -92,9 +92,18 @@ data:
   {{- if .Values.insights.forwarding.enabled }}
   {{- $managedKeys = concat $managedKeys (list "SOLACE_CUSTOM_INSIGHTS_ENABLED" "INSIGHTS_AGENT_TELEMETRY_ENABLED") }}
   {{- end }}
+  {{- /* INSIGHTS_AGENT_API_KEY / INSIGHTS_AGENT_SITE default to "" in the chart values and
+         Helm merges those empty defaults in even when the operator omits them. In forwarding
+         mode they are optional (the agent supplies its own), so skip them when empty rather
+         than emitting blank env vars. In standard mode validation above already requires them
+         to be non-empty. The container consumes this Secret via envFrom, so an omitted key
+         simply means the env var is unset and the pod still starts normally. */ -}}
+  {{- $skipIfEmpty := list "INSIGHTS_AGENT_API_KEY" "INSIGHTS_AGENT_SITE" }}
   {{- range $key, $value := .Values.insights.environmentVariables }}
   {{- if not (has $key $managedKeys) }}
+  {{- if not (and (has $key $skipIfEmpty) (eq ($value | toString) "")) }}
   {{ $key }}: {{ $value | b64enc | quote }}
+  {{- end }}
   {{- end }}
   {{- end }}
 stringData:

--- a/pubsubplus/templates/insights-logs-config.yaml
+++ b/pubsubplus/templates/insights-logs-config.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.insights.enabled .Values.insights.forwarding.enabled }}
+{{- if .Values.insights.forwarding.logsConfig }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "solace.fullname" . }}-logs-config
+  labels:
+    app.kubernetes.io/name: {{ template "solace.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+data:
+  logs.yml: |-
+{{ .Values.insights.forwarding.logsConfig | indent 4 }}
+{{- end }}
+{{- end }}

--- a/pubsubplus/templates/insights-otel-config-secret.yaml
+++ b/pubsubplus/templates/insights-otel-config-secret.yaml
@@ -1,5 +1,13 @@
 {{- if and .Values.insights.enabled .Values.insights.forwarding.enabled }}
-{{- if .Values.insights.forwarding.otelConfig }}
+{{- $f := .Values.insights.forwarding }}
+{{- /* Per-broker-node OTel configs, keyed by pod index (primary=0, backup=1, monitor=2).
+       Each node uses its per-node value when set, otherwise falls back to otelConfig.
+       The agent mounts otel-config-<pod-index>.yaml via subPathExpr. */ -}}
+{{- $nodes := list (dict "idx" 0 "cfg" (default $f.otelConfig $f.otelConfigPrimary)) }}
+{{- if .Values.solace.redundancy }}
+{{- $nodes = append $nodes (dict "idx" 1 "cfg" (default $f.otelConfig $f.otelConfigBackup)) }}
+{{- $nodes = append $nodes (dict "idx" 2 "cfg" (default $f.otelConfig $f.otelConfigMonitor)) }}
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -11,7 +19,8 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
 type: Opaque
 stringData:
-  otel-config.yaml: |-
-{{ .Values.insights.forwarding.otelConfig | indent 4 }}
+{{- range $n := $nodes }}
+  otel-config-{{ $n.idx }}.yaml: |-
+{{ $n.cfg | indent 4 }}
 {{- end }}
 {{- end }}

--- a/pubsubplus/templates/insights-otel-config-secret.yaml
+++ b/pubsubplus/templates/insights-otel-config-secret.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.insights.enabled .Values.insights.forwarding.enabled }}
+{{- if .Values.insights.forwarding.otelConfig }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "solace.fullname" . }}-otel-config
+  labels:
+    app.kubernetes.io/name: {{ template "solace.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+type: Opaque
+stringData:
+  otel-config.yaml: |-
+{{ .Values.insights.forwarding.otelConfig | indent 4 }}
+{{- end }}
+{{- end }}

--- a/pubsubplus/templates/insights-otel-config-secret.yaml
+++ b/pubsubplus/templates/insights-otel-config-secret.yaml
@@ -1,8 +1,10 @@
 {{- if and .Values.insights.enabled .Values.insights.forwarding.enabled }}
 {{- $f := .Values.insights.forwarding }}
-{{- /* Per-broker-node OTel configs, keyed by pod index (primary=0, backup=1, monitor=2).
-       Each node uses its per-node value when set, otherwise falls back to otelConfig.
-       The agent mounts otel-config-<pod-index>.yaml via subPathExpr. */ -}}
+{{- $fullname := include "solace.fullname" . }}
+{{- /* Per-broker-node OTel configs, keyed by pod name <fullname>-<ordinal>
+       (primary=0, backup=1, monitor=2). Each node uses its per-node value when set,
+       otherwise falls back to otelConfig. The agent mounts its own key via
+       subPathExpr otel-config-$(POD_NAME).yaml. */ -}}
 {{- $nodes := list (dict "idx" 0 "cfg" (default $f.otelConfig $f.otelConfigPrimary)) }}
 {{- if .Values.solace.redundancy }}
 {{- $nodes = append $nodes (dict "idx" 1 "cfg" (default $f.otelConfig $f.otelConfigBackup)) }}
@@ -20,7 +22,7 @@ metadata:
 type: Opaque
 stringData:
 {{- range $n := $nodes }}
-  otel-config-{{ $n.idx }}.yaml: |-
+  otel-config-{{ $fullname }}-{{ $n.idx }}.yaml: |-
 {{ $n.cfg | indent 4 }}
 {{- end }}
 {{- end }}

--- a/pubsubplus/templates/solaceStatefulSet.yaml
+++ b/pubsubplus/templates/solaceStatefulSet.yaml
@@ -299,7 +299,8 @@ spec:
 {{- if .Values.insights.forwarding.enabled }}
           - name: otel-config
             mountPath: /etc/datadog-agent/otel-config.yaml
-            subPath: otel-config.yaml
+            # Each node mounts its own config by pod index (primary=0, backup=1, monitor=2).
+            subPathExpr: otel-config-$(INSIGHTS_AGENT_NODE_ROLE).yaml
             readOnly: true
 {{- if .Values.insights.forwarding.logsConfig }}
           - name: logs-config
@@ -333,10 +334,9 @@ spec:
 {{- if and .Values.insights.enabled .Values.insights.forwarding.enabled }}
         - name: otel-config
           secret:
+            # All per-node keys (otel-config-0/1/2.yaml) are projected; the container
+            # selects its own via subPathExpr on the pod index.
             secretName: {{ template "solace.fullname" . }}-otel-config
-            items:
-              - key: otel-config.yaml
-                path: otel-config.yaml
             defaultMode: 0444
 {{- if .Values.insights.forwarding.logsConfig }}
         - name: logs-config

--- a/pubsubplus/templates/solaceStatefulSet.yaml
+++ b/pubsubplus/templates/solaceStatefulSet.yaml
@@ -269,8 +269,11 @@ spec:
             cpu: {{ .Values.insights.resources.requests.cpu | default "200m" }}
           limits:
 {{- $insightsLimits := .Values.insights.resources.limits | default dict }}
-            memory: {{ $insightsLimits.memory | default (include "insights.agentLimitMemory" .) }}
-            cpu: {{ $insightsLimits.cpu | default (include "insights.agentLimitCpu" .) }}
+            {{- /* Use the explicit limit when set; otherwise compute it. The helper is
+                   only invoked in the else branch so an explicit limit bypasses it
+                   (and its unknown-solace.size guard). */}}
+            memory: {{ if $insightsLimits.memory }}{{ $insightsLimits.memory }}{{ else }}{{ include "insights.agentLimitMemory" . }}{{ end }}
+            cpu: {{ if $insightsLimits.cpu }}{{ $insightsLimits.cpu }}{{ else }}{{ include "insights.agentLimitCpu" . }}{{ end }}
         env:
         - name: INSIGHTS_AGENT_BROKER_HOSTNAME_OVERRIDE
           valueFrom:

--- a/pubsubplus/templates/solaceStatefulSet.yaml
+++ b/pubsubplus/templates/solaceStatefulSet.yaml
@@ -280,6 +280,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.labels['apps.kubernetes.io/pod-index']
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         envFrom:
           - secretRef:
               name: {{ template "solace.fullname" . }}-insights-agent-env-secrets
@@ -299,8 +303,10 @@ spec:
 {{- if .Values.insights.forwarding.enabled }}
           - name: otel-config
             mountPath: /etc/datadog-agent/otel-config.yaml
-            # Each node mounts its own config by pod index (primary=0, backup=1, monitor=2).
-            subPathExpr: otel-config-$(INSIGHTS_AGENT_NODE_ROLE).yaml
+            # Each pod mounts its own config, keyed by pod name (<fullname>-<ordinal>).
+            # Uses metadata.name (present on all Kubernetes versions) rather than the
+            # apps.kubernetes.io/pod-index label, which only exists on newer clusters.
+            subPathExpr: otel-config-$(POD_NAME).yaml
             readOnly: true
 {{- if .Values.insights.forwarding.logsConfig }}
           - name: logs-config
@@ -334,8 +340,8 @@ spec:
 {{- if and .Values.insights.enabled .Values.insights.forwarding.enabled }}
         - name: otel-config
           secret:
-            # All per-node keys (otel-config-0/1/2.yaml) are projected; the container
-            # selects its own via subPathExpr on the pod index.
+            # All per-node keys (otel-config-<fullname>-<ordinal>.yaml) are projected;
+            # the container selects its own via subPathExpr on the pod name.
             secretName: {{ template "solace.fullname" . }}-otel-config
             defaultMode: 0444
 {{- if .Values.insights.forwarding.logsConfig }}

--- a/pubsubplus/templates/solaceStatefulSet.yaml
+++ b/pubsubplus/templates/solaceStatefulSet.yaml
@@ -262,14 +262,15 @@ spec:
 {{- if ( .Values.insights.enabled) }}
       - name: insights-agent
         image: {{ .Values.insights.image.repository }}:{{ .Values.insights.image.tag }}
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Values.insights.image.pullPolicy | default "Always" }}
         resources:
           requests:
-            memory: {{ .Values.insights.resources.requests.memory }}
-            cpu: {{ .Values.insights.resources.requests.cpu }}
+            memory: {{ .Values.insights.resources.requests.memory | default "256Mi" }}
+            cpu: {{ .Values.insights.resources.requests.cpu | default "200m" }}
           limits:
-            memory: {{ .Values.insights.resources.limits.memory }}
-            cpu: {{ .Values.insights.resources.limits.cpu }}
+{{- $insightsLimits := .Values.insights.resources.limits | default dict }}
+            memory: {{ $insightsLimits.memory | default (include "insights.agentLimitMemory" .) }}
+            cpu: {{ $insightsLimits.cpu | default (include "insights.agentLimitCpu" .) }}
         env:
         - name: INSIGHTS_AGENT_BROKER_HOSTNAME_OVERRIDE
           valueFrom:
@@ -295,6 +296,18 @@ spec:
           - name: data
             mountPath: /opt/datadog-agent/run
             subPath: opt/datadog-agent/run
+{{- if .Values.insights.forwarding.enabled }}
+          - name: otel-config
+            mountPath: /etc/datadog-agent/otel-config.yaml
+            subPath: otel-config.yaml
+            readOnly: true
+{{- if .Values.insights.forwarding.logsConfig }}
+          - name: logs-config
+            mountPath: /etc/datadog-agent/conf.d/solace.d/logs.yml
+            subPath: logs.yml
+            readOnly: true
+{{- end }}
+{{- end }}
 {{- end }}
       volumes:
         - name: podinfo
@@ -316,6 +329,24 @@ spec:
           secret:
             secretName: {{ template "solace.fullname" . }}-insights-secrets
             defaultMode: 0400
+{{- end }}
+{{- if and .Values.insights.enabled .Values.insights.forwarding.enabled }}
+        - name: otel-config
+          secret:
+            secretName: {{ template "solace.fullname" . }}-otel-config
+            items:
+              - key: otel-config.yaml
+                path: otel-config.yaml
+            defaultMode: 0444
+{{- if .Values.insights.forwarding.logsConfig }}
+        - name: logs-config
+          configMap:
+            name: {{ template "solace.fullname" . }}-logs-config
+            items:
+              - key: logs.yml
+                path: logs.yml
+            defaultMode: 0444
+{{- end }}
 {{- end }}
 {{- if and (.Values.tls) (.Values.tls.enabled) }}
         - name: server-certs

--- a/pubsubplus/values.schema.json
+++ b/pubsubplus/values.schema.json
@@ -320,7 +320,19 @@
                         },
                         "otelConfig": {
                             "type": "string",
-                            "description": "Inline otel-config.yaml content. Required when forwarding.enabled=true; rendered into a chart-managed Secret."
+                            "description": "Inline otel-config.yaml content. Required when forwarding.enabled=true (unless per-node configs are set); rendered into a chart-managed Secret."
+                        },
+                        "otelConfigPrimary": {
+                            "type": "string",
+                            "description": "Per-node otel-config.yaml for the primary node (pod-0) in HA. Falls back to otelConfig when empty."
+                        },
+                        "otelConfigBackup": {
+                            "type": "string",
+                            "description": "Per-node otel-config.yaml for the backup node (pod-1) in HA. Falls back to otelConfig when empty."
+                        },
+                        "otelConfigMonitor": {
+                            "type": "string",
+                            "description": "Per-node otel-config.yaml for the monitor node (pod-2) in HA. Falls back to otelConfig when empty."
                         },
                         "logsConfig": {
                             "type": "string",

--- a/pubsubplus/values.schema.json
+++ b/pubsubplus/values.schema.json
@@ -247,6 +247,10 @@
                         "tag": {
                             "type": "string",
                             "description": "Image tag for the Insights Agent"
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Image pull policy for the Insights Agent container (Always, IfNotPresent, or Never). Defaults to Always."
                         }
                     }
                 },
@@ -303,6 +307,24 @@
                                     "description": "Maximum memory resource allowed"
                                 }
                             }
+                        }
+                    }
+                },
+                "forwarding": {
+                    "type": "object",
+                    "description": "Insights Agent Pro / third-party forwarding configuration",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable Insights Agent Pro (third-party forwarding via the co-resident OTel collector)"
+                        },
+                        "otelConfig": {
+                            "type": "string",
+                            "description": "Inline otel-config.yaml content. Required when forwarding.enabled=true; rendered into a chart-managed Secret."
+                        },
+                        "logsConfig": {
+                            "type": "string",
+                            "description": "Inline logs.yml content overriding the agent's solace.d/logs.yml. Only takes effect when forwarding.enabled=true; rendered into a chart-managed ConfigMap."
                         }
                     }
                 }

--- a/pubsubplus/values.yaml
+++ b/pubsubplus/values.yaml
@@ -270,9 +270,11 @@ insights:
   enabled: false
 
   environmentVariables:
-    # API key for your Solace Insights subscription, available from the Solace Cloud Console. This value is required.
+    # API key for your Solace Insights subscription, available from the Solace Cloud Console.
+    # Required in standard mode; optional when forwarding.enabled=true (the agent does not use it).
     INSIGHTS_AGENT_API_KEY: ""
-    # Site location where broker metrics and logs will flow, available from the Solace Cloud Console. This value is required.
+    # Site location where broker metrics and logs will flow, available from the Solace Cloud Console.
+    # Required in standard mode; optional when forwarding.enabled=true (falls back to the agent default).
     INSIGHTS_AGENT_SITE: ""
     # Tags for metrics and logs, available from the Solace Cloud Console. This value is required.
     INSIGHTS_AGENT_TAGS: ""

--- a/pubsubplus/values.yaml
+++ b/pubsubplus/values.yaml
@@ -282,7 +282,7 @@ insights:
     # agent verbatim. The following are honored only when forwarding.enabled=true:
     #   # GOMEMLIMIT for the co-resident OTel collector. Optional: when forwarding is enabled and
     #   # this is not set, the chart derives it as 80% of the agent memory headroom (the effective
-    #   # memory limit minus requests.memory). Set it here to override the derived value.
+    #   # memory limit minus the fixed 256Mi base). Set it here to override the derived value.
     #   INSIGHTS_AGENT_GOMEMLIMIT: "<N>MiB"
     #   # Dual-write to Datadog SaaS in addition to OTel forwarding:
     #   INSIGHTS_AGENT_LOGS_ENABLED: "true"
@@ -307,9 +307,12 @@ insights:
       # Minimum memory resource required by the insights-agent container
       memory: 256Mi
     # Maximum CPU/memory limits for the insights-agent container.
-    # When not set, each limit is computed per solace.size as a base plus per-size-class
-    # headroom for the co-resident OTel collector. The base is the corresponding requests
-    # value when set, otherwise 200m CPU / 256Mi memory (requests must use Mi or Gi units).
+    # When not set, each limit is computed per solace.size as a FIXED base (200m CPU /
+    # 256Mi memory) plus a per-size-class headroom for the co-resident OTel collector. The
+    # base is fixed (not the requests value), so the computed limit is a stable per-size
+    # value — set requests equal to it and leave limits unset for Guaranteed QoS. If a
+    # request is higher than base + headroom, the limit is raised to the request
+    # (requests memory must use Mi or Gi units).
     # NOTE: the headroom is selected by solace.size. When solace.systemScaling is used
     # (solace.size is ignored for broker sizing), the headroom falls back to the
     # solace.size default tier — set limits explicitly below to size the agent for a

--- a/pubsubplus/values.yaml
+++ b/pubsubplus/values.yaml
@@ -280,7 +280,10 @@ insights:
     INSIGHTS_AGENT_TAGS: ""
     # Additional agent settings are supplied here as plain env vars and passed through to the
     # agent verbatim. The following are honored only when forwarding.enabled=true:
-    #   INSIGHTS_AGENT_GOMEMLIMIT: "<N>MiB"        # GOMEMLIMIT for the co-resident OTel collector
+    #   # GOMEMLIMIT for the co-resident OTel collector. Optional: when forwarding is enabled and
+    #   # this is not set, the chart derives it as 80% of the agent memory headroom (the effective
+    #   # memory limit minus requests.memory). Set it here to override the derived value.
+    #   INSIGHTS_AGENT_GOMEMLIMIT: "<N>MiB"
     #   # Dual-write to Datadog SaaS in addition to OTel forwarding:
     #   INSIGHTS_AGENT_LOGS_ENABLED: "true"
     #   INSIGHTS_AGENT_ADDITIONAL_ENDPOINTS: '{"https://app.<site>":["<key1>","<key2>"]}'

--- a/pubsubplus/values.yaml
+++ b/pubsubplus/values.yaml
@@ -276,6 +276,13 @@ insights:
     INSIGHTS_AGENT_SITE: ""
     # Tags for metrics and logs, available from the Solace Cloud Console. This value is required.
     INSIGHTS_AGENT_TAGS: ""
+    # Additional agent settings are supplied here as plain env vars and passed through to the
+    # agent verbatim. The following are honored only when forwarding.enabled=true:
+    #   INSIGHTS_AGENT_GOMEMLIMIT: "<N>MiB"        # GOMEMLIMIT for the co-resident OTel collector
+    #   # Dual-write to Datadog SaaS in addition to OTel forwarding:
+    #   INSIGHTS_AGENT_LOGS_ENABLED: "true"
+    #   INSIGHTS_AGENT_ADDITIONAL_ENDPOINTS: '{"https://app.<site>":["<key1>","<key2>"]}'
+    #   INSIGHTS_AGENT_LOGS_CONFIG_ADDITIONAL_ENDPOINTS: '[{"api_key":"<key1>","host":"agent-http-intake.logs.<site>","use_compression":true,"compression_level":2}]'
 
   image:
     # Image repository for the Insights Agent container
@@ -284,6 +291,9 @@ insights:
     tag: latest
     # Image pull secret name for the Insights Agent container. The pull secret is available from the Solace Cloud Console.
     pullSecretName: gcr-reg-secret
+    # Image pull policy for the Insights Agent container. Defaults to "Always".
+    # Set to "IfNotPresent" or "Never" for air-gapped clusters with pre-loaded images.
+    pullPolicy: Always
 
   resources:
     requests:
@@ -291,8 +301,45 @@ insights:
       cpu: 200m
       # Minimum memory resource required by the insights-agent container
       memory: 256Mi
-    limits:
-      # Maximum CPU resource the insights-agent container can use
-      cpu: 200m
-      # Maximum memory resource the insights-agent container can use
-      memory: 512Mi
+    # Maximum CPU/memory limits for the insights-agent container.
+    # When not set, each limit is computed per solace.size as a base plus per-size-class
+    # headroom for the co-resident OTel collector. The base is the corresponding requests
+    # value when set, otherwise 200m CPU / 256Mi memory (requests must use Mi or Gi units).
+    # NOTE: the headroom is selected by solace.size. When solace.systemScaling is used
+    # (solace.size is ignored for broker sizing), the headroom falls back to the
+    # solace.size default tier — set limits explicitly below to size the agent for a
+    # custom-scaled broker.
+    # Set either/both here to override with explicit final values (used verbatim):
+    # limits:
+    #   cpu: "1"
+    #   memory: 1Gi
+
+  # Insights Agent Pro / third-party forwarding configuration.
+  # When forwarding.enabled is false (default), the agent ships metrics and logs
+  # directly to Datadog SaaS (standard mode) and none of the keys below take effect.
+  forwarding:
+    # Master switch for Insights Agent Pro mode. When true, the agent's
+    # custom-entrypoint.sh flips to ship through the co-resident OTel collector.
+    enabled: false
+
+    # Inline OTel collector configuration (otel-config.yaml). Required when
+    # forwarding.enabled=true. Rendered into a chart-managed Secret and mounted at
+    # /etc/datadog-agent/otel-config.yaml.
+    #   otelConfig: |
+    #     receivers: { ... }
+    #     exporters: { ... }
+    #     service:
+    #       pipelines: { ... }
+    otelConfig: ""
+
+    # Optional inline override of the Datadog agent's Solace log-collection config
+    # (/etc/datadog-agent/conf.d/solace.d/logs.yml). Rendered into a chart-managed
+    # ConfigMap and mounted over that single file. Only takes effect when
+    # forwarding.enabled=true; leave empty to keep the agent image's default logs.yml.
+    #   logsConfig: |
+    #     logs:
+    #       - type: file
+    #         path: /jail/logs/*.log
+    #         service: solace
+    #         source: solace
+    logsConfig: ""

--- a/pubsubplus/values.yaml
+++ b/pubsubplus/values.yaml
@@ -324,15 +324,27 @@ insights:
     # custom-entrypoint.sh flips to ship through the co-resident OTel collector.
     enabled: false
 
-    # Inline OTel collector configuration (otel-config.yaml). Required when
-    # forwarding.enabled=true. Rendered into a chart-managed Secret and mounted at
-    # /etc/datadog-agent/otel-config.yaml.
+    # Inline OTel collector configuration (otel-config.yaml). Used by all nodes; required
+    # when forwarding.enabled=true unless the per-node configs below are set. Rendered into
+    # a chart-managed Secret and mounted at /etc/datadog-agent/otel-config.yaml. Tip: load
+    # from a file with `--set-file insights.forwarding.otelConfig=./otel-config.yaml`.
     #   otelConfig: |
     #     receivers: { ... }
     #     exporters: { ... }
     #     service:
     #       pipelines: { ... }
     otelConfig: ""
+
+    # Optional per-node OTel configs for an HA deployment (solace.redundancy=true).
+    # When set, each broker node mounts its own config; a node falls back to otelConfig
+    # when its per-node value is empty. Map to the Solace HA roles (pod-0/1/2). Load each
+    # from a file, e.g.:
+    #   --set-file insights.forwarding.otelConfigPrimary=./otel-primary.yaml
+    #   --set-file insights.forwarding.otelConfigBackup=./otel-backup.yaml
+    #   --set-file insights.forwarding.otelConfigMonitor=./otel-monitor.yaml
+    otelConfigPrimary: ""   # pod-0 (primary)
+    otelConfigBackup: ""    # pod-1 (backup)
+    otelConfigMonitor: ""   # pod-2 (monitor)
 
     # Optional inline override of the Datadog agent's Solace log-collection config
     # (/etc/datadog-agent/conf.d/solace.d/logs.yml). Rendered into a chart-managed

--- a/tests/python/unit/test_insights.py
+++ b/tests/python/unit/test_insights.py
@@ -83,6 +83,7 @@ def test_insights_container_added_to_pod(render_helm_template, test_values):
         insights_container["resources"]["requests"]["memory"]
         == test_values["insights"]["resources"]["requests"]["memory"]
     )
+    # limits are provided in test_values, so they are used verbatim.
     assert (
         insights_container["resources"]["limits"]["cpu"]
         == test_values["insights"]["resources"]["limits"]["cpu"]

--- a/tests/python/unit/test_insights_forwarding.py
+++ b/tests/python/unit/test_insights_forwarding.py
@@ -309,6 +309,50 @@ def test_standard_mode_still_requires_api_key(render_helm_template, base_values)
 
 
 # --------------------------------------------------------------------------- #
+# Empty API_KEY / SITE suppression (forwarding mode)
+# --------------------------------------------------------------------------- #
+def test_empty_api_key_site_suppressed_in_forwarding(render_helm_template, base_values):
+    # The chart's empty defaults for API_KEY/SITE are merged in even when omitted; in
+    # forwarding mode they are optional, so empty values must not be emitted as blank env vars.
+    values = copy.deepcopy(base_values)
+    values["insights"]["environmentVariables"]["INSIGHTS_AGENT_API_KEY"] = ""
+    values["insights"]["environmentVariables"]["INSIGHTS_AGENT_SITE"] = ""
+    values["insights"]["forwarding"] = {"enabled": True, "otelConfig": "service: {}\n"}
+    data = _env_secret(render_helm_template(values))["data"]
+    assert "INSIGHTS_AGENT_API_KEY" not in data
+    assert "INSIGHTS_AGENT_SITE" not in data
+    # Non-empty operator vars are unaffected.
+    assert "INSIGHTS_AGENT_TAGS" in data
+
+
+def test_nonempty_api_key_site_passthrough_in_forwarding(render_helm_template, base_values):
+    # If the operator does set them in forwarding mode, they pass through unchanged.
+    values = copy.deepcopy(base_values)
+    values["insights"]["environmentVariables"]["INSIGHTS_AGENT_API_KEY"] = "k"
+    values["insights"]["environmentVariables"]["INSIGHTS_AGENT_SITE"] = "datadoghq.eu"
+    values["insights"]["forwarding"] = {"enabled": True, "otelConfig": "service: {}\n"}
+    data = _env_secret(render_helm_template(values))["data"]
+    assert base64.b64decode(data["INSIGHTS_AGENT_API_KEY"]).decode() == "k"
+    assert base64.b64decode(data["INSIGHTS_AGENT_SITE"]).decode() == "datadoghq.eu"
+
+
+def test_env_secret_consumed_via_envfrom(render_helm_template, base_values):
+    # Suppressing optional keys is only safe because the container loads the env secret via
+    # envFrom (a missing key just means the var is unset). A non-optional secretKeyRef to a
+    # suppressed key would fail the pod with CreateContainerConfigError, so guard against it.
+    values = copy.deepcopy(base_values)
+    values["insights"]["forwarding"] = {"enabled": True, "otelConfig": "service: {}\n"}
+    c = _insights_container(render_helm_template(values))
+    env_from_secrets = [
+        e.get("secretRef", {}).get("name", "") for e in c.get("envFrom", [])
+    ]
+    assert any(n.endswith("-insights-agent-env-secrets") for n in env_from_secrets)
+    for e in c.get("env", []):
+        ref = e.get("valueFrom", {}).get("secretKeyRef", {})
+        assert not ref.get("name", "").endswith("-insights-agent-env-secrets")
+
+
+# --------------------------------------------------------------------------- #
 # Backward compatibility
 # --------------------------------------------------------------------------- #
 def test_forwarding_disabled_is_noop(render_helm_template, base_values):

--- a/tests/python/unit/test_insights_forwarding.py
+++ b/tests/python/unit/test_insights_forwarding.py
@@ -152,6 +152,28 @@ def test_forwarding_env_vars_pass_through(render_helm_template, base_values):
     assert "INSIGHTS_AGENT_LOGS_CONFIG_ADDITIONAL_ENDPOINTS" not in string_data
 
 
+def test_forwarding_does_not_require_api_key_or_site(render_helm_template, base_values):
+    # In forwarding mode INSIGHTS_AGENT_API_KEY / INSIGHTS_AGENT_SITE are optional
+    # (the agent overrides/derives them); only TAGS remains required.
+    values = copy.deepcopy(base_values)
+    values["insights"]["environmentVariables"] = {"INSIGHTS_AGENT_TAGS": "env:dev"}
+    values["insights"]["forwarding"] = {"enabled": True, "otelConfig": "service: {}\n"}
+    # Renders without error despite no API_KEY/SITE.
+    assert _otel_secret(render_helm_template(values)) is not None
+
+
+def test_standard_mode_still_requires_api_key(render_helm_template, base_values):
+    # With forwarding disabled (standard mode), API_KEY remains required.
+    values = copy.deepcopy(base_values)
+    values["insights"]["environmentVariables"] = {
+        "INSIGHTS_AGENT_SITE": "datadoghq.com",
+        "INSIGHTS_AGENT_TAGS": "env:dev",
+    }
+    with pytest.raises(Exception) as e:
+        render_helm_template(values)
+    assert "INSIGHTS_AGENT_API_KEY must be defined" in str(e.value)
+
+
 # --------------------------------------------------------------------------- #
 # Backward compatibility
 # --------------------------------------------------------------------------- #

--- a/tests/python/unit/test_insights_forwarding.py
+++ b/tests/python/unit/test_insights_forwarding.py
@@ -82,10 +82,10 @@ def test_forwarding_only_renders_otel_secret_and_mount(render_helm_template, bas
     }
     resources = render_helm_template(values)
 
-    # Chart-managed OTel config Secret is rendered.
+    # Chart-managed OTel config Secret is rendered (keyed per pod index).
     otel_secret = _otel_secret(resources)
     assert otel_secret is not None
-    assert "otel-config.yaml" in otel_secret["stringData"]
+    assert "otel-config-0.yaml" in otel_secret["stringData"]
 
     # Only SOLACE_CUSTOM_INSIGHTS_ENABLED is chart-managed in stringData.
     env_secret = _env_secret(resources)
@@ -103,11 +103,67 @@ def test_forwarding_only_renders_otel_secret_and_mount(render_helm_template, bas
         if m["name"] == "otel-config"
     )
     assert mount["mountPath"] == "/etc/datadog-agent/otel-config.yaml"
-    assert mount["subPath"] == "otel-config.yaml"
+    assert mount["subPathExpr"] == "otel-config-$(INSIGHTS_AGENT_NODE_ROLE).yaml"
     assert mount["readOnly"] is True
 
     volume = next(v for v in _volumes(resources) if v["name"] == "otel-config")
     assert volume["secret"]["secretName"].endswith("-otel-config")
+
+
+# --------------------------------------------------------------------------- #
+# Per-node otelConfig (HA)
+# --------------------------------------------------------------------------- #
+def test_otel_per_node_configs_keyed_by_pod_index(render_helm_template, base_values):
+    values = copy.deepcopy(base_values)
+    values["solace"] = {"size": "dev", "redundancy": True}
+    values["insights"]["forwarding"] = {
+        "enabled": True,
+        "otelConfigPrimary": "service: {role: primary}\n",
+        "otelConfigBackup": "service: {role: backup}\n",
+        "otelConfigMonitor": "service: {role: monitor}\n",
+    }
+    sd = _otel_secret(render_helm_template(values))["stringData"]
+    assert "role: primary" in sd["otel-config-0.yaml"]
+    assert "role: backup" in sd["otel-config-1.yaml"]
+    assert "role: monitor" in sd["otel-config-2.yaml"]
+
+
+def test_otel_per_node_falls_back_to_otel_config(render_helm_template, base_values):
+    # backup/monitor unset -> fall back to otelConfig; primary overrides.
+    values = copy.deepcopy(base_values)
+    values["solace"] = {"size": "dev", "redundancy": True}
+    values["insights"]["forwarding"] = {
+        "enabled": True,
+        "otelConfig": "service: {role: shared}\n",
+        "otelConfigPrimary": "service: {role: primary}\n",
+    }
+    sd = _otel_secret(render_helm_template(values))["stringData"]
+    assert "role: primary" in sd["otel-config-0.yaml"]
+    assert "role: shared" in sd["otel-config-1.yaml"]
+    assert "role: shared" in sd["otel-config-2.yaml"]
+
+
+def test_otel_non_ha_renders_only_index_0(render_helm_template, base_values):
+    values = copy.deepcopy(base_values)
+    values["solace"] = {"size": "dev"}  # redundancy defaults false
+    values["insights"]["forwarding"] = {"enabled": True, "otelConfig": "service: {}\n"}
+    sd = _otel_secret(render_helm_template(values))["stringData"]
+    assert "otel-config-0.yaml" in sd
+    assert "otel-config-1.yaml" not in sd
+    assert "otel-config-2.yaml" not in sd
+
+
+def test_otel_ha_requires_backup_config_when_no_fallback(render_helm_template, base_values):
+    values = copy.deepcopy(base_values)
+    values["solace"] = {"size": "dev", "redundancy": True}
+    # primary set, but no otelConfig fallback and no backup/monitor -> fail for backup.
+    values["insights"]["forwarding"] = {
+        "enabled": True,
+        "otelConfigPrimary": "service: {}\n",
+    }
+    with pytest.raises(Exception) as e:
+        render_helm_template(values)
+    assert "backup node" in str(e.value)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/python/unit/test_insights_forwarding.py
+++ b/tests/python/unit/test_insights_forwarding.py
@@ -279,11 +279,11 @@ def test_gomemlimit_fails_when_explicit_limit_has_no_headroom(render_helm_templa
     # Explicit limit not above requests and no operator GOMEMLIMIT -> fail-fast.
     values = copy.deepcopy(base_values)
     values["solace"] = {"size": "dev"}
-    values["insights"]["resources"]["limits"]["memory"] = "256Mi"  # == requests
+    values["insights"]["resources"]["limits"]["memory"] = "256Mi"  # == agent base
     values["insights"]["forwarding"] = {"enabled": True, "otelConfig": "service: {}\n"}
     with pytest.raises(Exception) as e:
         render_helm_template(values)
-    assert "does not exceed requests" in str(e.value)
+    assert "at or below the agent base" in str(e.value)
 
 
 def test_forwarding_does_not_require_api_key_or_site(render_helm_template, base_values):
@@ -429,15 +429,46 @@ def test_agent_limits_computed_from_default_base(render_helm_template, base_valu
     assert float(container["resources"]["limits"]["cpu"]) == 0.7
 
 
-def test_agent_limits_computed_base_follows_requests(render_helm_template, base_values):
+def test_computed_limit_independent_of_requests_below_it(render_helm_template, base_values):
+    # The computed limit uses a fixed base (not requests); requests below it don't change it.
     values = copy.deepcopy(base_values)
     del values["insights"]["resources"]["limits"]
     values["insights"]["resources"]["requests"] = {"cpu": "1", "memory": "1Gi"}
     values["solace"] = {"size": "prod10k"}
     container = _insights_container(render_helm_template(values))
-    # base = requests (1Gi=1024Mi / 1 core) + prod10k headroom (2048Mi / 1000m).
-    assert container["resources"]["limits"]["memory"] == "3072Mi"
-    assert float(container["resources"]["limits"]["cpu"]) == 2.0
+    # computed = 256Mi + 2048Mi = 2304Mi; 200m + 1000m = 1.2 cores. Requests (1024Mi / 1 core)
+    # are below those, so the limit stays at the computed value.
+    assert container["resources"]["limits"]["memory"] == "2304Mi"
+    assert float(container["resources"]["limits"]["cpu"]) == 1.2
+
+
+def test_requests_equal_limits_is_guaranteed_qos(render_helm_template, base_values):
+    # Set requests to the per-size value and leave limits unset -> requests == limits
+    # (Guaranteed QoS) with a valid derived GOMEMLIMIT (measured from the fixed 256Mi base).
+    values = copy.deepcopy(base_values)
+    del values["insights"]["resources"]["limits"]
+    values["solace"] = {"size": "dev"}
+    values["insights"]["resources"]["requests"] = {"cpu": "700m", "memory": "768Mi"}
+    values["insights"]["forwarding"] = {"enabled": True, "otelConfig": "service: {}\n"}
+    resources = render_helm_template(values)
+    c = _insights_container(resources)
+    assert c["resources"]["limits"]["memory"] == "768Mi"
+    assert c["resources"]["limits"]["memory"] == c["resources"]["requests"]["memory"]
+    assert float(c["resources"]["limits"]["cpu"]) == 0.7
+    assert _env_secret(resources)["stringData"]["INSIGHTS_AGENT_GOMEMLIMIT"] == "409MiB"
+
+
+def test_computed_limit_clamps_up_to_large_request(render_helm_template, base_values):
+    # A request above base + headroom raises the limit to the request, and GOMEMLIMIT
+    # scales with it (80% of limit - 256Mi base).
+    values = copy.deepcopy(base_values)
+    del values["insights"]["resources"]["limits"]
+    values["solace"] = {"size": "dev"}
+    values["insights"]["resources"]["requests"] = {"cpu": "200m", "memory": "1Gi"}
+    values["insights"]["forwarding"] = {"enabled": True, "otelConfig": "service: {}\n"}
+    resources = render_helm_template(values)
+    assert _insights_container(resources)["resources"]["limits"]["memory"] == "1024Mi"
+    assert _env_secret(resources)["stringData"]["INSIGHTS_AGENT_GOMEMLIMIT"] == "614MiB"
 
 
 def test_agent_limits_verbatim_when_set(render_helm_template, base_values):
@@ -450,14 +481,14 @@ def test_agent_limits_verbatim_when_set(render_helm_template, base_values):
 
 
 def test_agent_limits_fractional_mi_request_not_below_request(render_helm_template, base_values):
-    # Regression: a fractional-Mi request must not parse to 0 and yield a limit
-    # below the request (which k8s would reject). 1536.5Mi ceils to 1537 + 512 = 2049Mi.
+    # Regression: a fractional-Mi request must ceil (not truncate) so the limit clamps up
+    # to a value not below the request. dev computed = 768Mi; 1536.5Mi ceils to 1537Mi.
     values = copy.deepcopy(base_values)
     del values["insights"]["resources"]["limits"]
     values["insights"]["resources"]["requests"] = {"cpu": "200m", "memory": "1536.5Mi"}
     values["solace"] = {"size": "dev"}
     container = _insights_container(render_helm_template(values))
-    assert container["resources"]["limits"]["memory"] == "2049Mi"
+    assert container["resources"]["limits"]["memory"] == "1537Mi"
 
 
 def test_agent_limits_fractional_gi_request(render_helm_template, base_values):
@@ -466,8 +497,8 @@ def test_agent_limits_fractional_gi_request(render_helm_template, base_values):
     values["insights"]["resources"]["requests"] = {"cpu": "200m", "memory": "1.5Gi"}
     values["solace"] = {"size": "prod1k"}
     container = _insights_container(render_helm_template(values))
-    # 1.5Gi = 1536Mi + prod1k headroom 1024Mi.
-    assert container["resources"]["limits"]["memory"] == "2560Mi"
+    # prod1k computed = 256+1024 = 1280Mi; request 1.5Gi=1536Mi clamps the limit up to 1536Mi.
+    assert container["resources"]["limits"]["memory"] == "1536Mi"
 
 
 def test_agent_limits_rejects_non_mi_gi_memory(render_helm_template, base_values):
@@ -527,13 +558,14 @@ def test_tls_disabled_uses_plain_semp_port(render_helm_template, base_values):
 
 
 def test_agent_limits_fractional_millicore_cpu_not_truncated(render_helm_template, base_values):
-    # "100.5m" must not truncate to 0; ceil(100.5)=101 + dev 500m = 601m = 0.601 cores.
+    # A fractional-millicore request above the computed limit must ceil (not truncate) when
+    # clamping. dev computed = 700m; request 1500.5m ceils to 1501m = 1.501 cores (not 1.5).
     values = copy.deepcopy(base_values)
     del values["insights"]["resources"]["limits"]
-    values["insights"]["resources"]["requests"] = {"cpu": "100.5m", "memory": "256Mi"}
+    values["insights"]["resources"]["requests"] = {"cpu": "1500.5m", "memory": "256Mi"}
     values["solace"] = {"size": "dev"}
     container = _insights_container(render_helm_template(values))
-    assert float(container["resources"]["limits"]["cpu"]) == 0.601
+    assert float(container["resources"]["limits"]["cpu"]) == 1.501
 
 
 def test_agent_limits_partial_override(render_helm_template, base_values):

--- a/tests/python/unit/test_insights_forwarding.py
+++ b/tests/python/unit/test_insights_forwarding.py
@@ -117,6 +117,30 @@ def test_forwarding_only_renders_otel_secret_and_mount(render_helm_template, bas
     assert volume["secret"]["secretName"].endswith("-otel-config")
 
 
+def test_chart_managed_keys_not_duplicated_in_data(render_helm_template, base_values):
+    # Keys the chart manages in stringData must not also be emitted in the data block
+    # (which would create conflicting duplicate keys). Operator-supplied custom vars
+    # still pass through to data.
+    values = copy.deepcopy(base_values)
+    values["insights"]["environmentVariables"].update(
+        {
+            "INSIGHTS_AGENT_SEMP_PORT": "9999",          # chart-managed (always)
+            "SOLACE_CUSTOM_INSIGHTS_ENABLED": "false",   # chart-managed (forwarding only)
+            "MY_CUSTOM_VAR": "keepme",                    # operator-supplied
+        }
+    )
+    values["insights"]["forwarding"] = {"enabled": True, "otelConfig": "service: {}\n"}
+    sec = _env_secret(render_helm_template(values))
+    data, string_data = sec["data"], sec["stringData"]
+
+    assert base64.b64decode(data["MY_CUSTOM_VAR"]).decode() == "keepme"
+    assert "INSIGHTS_AGENT_SEMP_PORT" not in data
+    assert "SOLACE_CUSTOM_INSIGHTS_ENABLED" not in data
+    # They appear once, in stringData, with the chart's values (operator value ignored).
+    assert string_data["INSIGHTS_AGENT_SEMP_PORT"] == "8080"
+    assert string_data["SOLACE_CUSTOM_INSIGHTS_ENABLED"] == "true"
+
+
 # --------------------------------------------------------------------------- #
 # Per-node otelConfig (HA)
 # --------------------------------------------------------------------------- #

--- a/tests/python/unit/test_insights_forwarding.py
+++ b/tests/python/unit/test_insights_forwarding.py
@@ -93,13 +93,14 @@ def test_forwarding_only_renders_otel_secret_and_mount(render_helm_template, bas
     assert otel_secret is not None
     assert _otel_key(0) in otel_secret["stringData"]
 
-    # In forwarding mode the chart manages these two keys in stringData.
+    # In forwarding mode the chart manages these keys in stringData.
     env_secret = _env_secret(resources)
     assert env_secret["stringData"]["SOLACE_CUSTOM_INSIGHTS_ENABLED"] == "true"
     assert env_secret["stringData"]["INSIGHTS_AGENT_TELEMETRY_ENABLED"] == "false"
-    # The chart no longer injects GOMEMLIMIT or the push env vars; those are
-    # operator-supplied via environmentVariables only.
-    assert "INSIGHTS_AGENT_GOMEMLIMIT" not in env_secret["stringData"]
+    # GOMEMLIMIT is derived from the agent memory headroom when the operator did not
+    # set it: 80% of (limits.memory - requests.memory) = 80% of (512Mi - 256Mi) = 204MiB.
+    assert env_secret["stringData"]["INSIGHTS_AGENT_GOMEMLIMIT"] == "204MiB"
+    # The Datadog push vars remain operator-supplied via environmentVariables only.
     assert "INSIGHTS_AGENT_LOGS_ENABLED" not in env_secret["stringData"]
     assert "INSIGHTS_AGENT_ADDITIONAL_ENDPOINTS" not in env_secret["stringData"]
 
@@ -231,12 +232,58 @@ def test_forwarding_env_vars_pass_through(render_helm_template, base_values):
         == logs_cfg
     )
 
-    # The chart must NOT emit its own copies into stringData (no clobbering).
+    # The chart must NOT emit its own copies into stringData (no clobbering). For
+    # GOMEMLIMIT specifically, an operator-supplied value suppresses the chart's
+    # computed injection so it appears only once (in data).
     string_data = env_secret.get("stringData", {})
     assert "INSIGHTS_AGENT_GOMEMLIMIT" not in string_data
     assert "INSIGHTS_AGENT_LOGS_ENABLED" not in string_data
     assert "INSIGHTS_AGENT_ADDITIONAL_ENDPOINTS" not in string_data
     assert "INSIGHTS_AGENT_LOGS_CONFIG_ADDITIONAL_ENDPOINTS" not in string_data
+
+
+# --------------------------------------------------------------------------- #
+# Derived INSIGHTS_AGENT_GOMEMLIMIT (forwarding mode, operator value not set)
+# --------------------------------------------------------------------------- #
+def test_gomemlimit_computed_from_size_delta(render_helm_template, base_values):
+    # No explicit limits -> effective limit is requests + per-size headroom, so
+    # GOMEMLIMIT = 80% of that headroom (the OTel collector's share).
+    # prod1k delta = 1024Mi -> 80% = 819MiB.
+    values = copy.deepcopy(base_values)
+    values["solace"] = {"size": "prod1k"}
+    del values["insights"]["resources"]["limits"]
+    values["insights"]["forwarding"] = {"enabled": True, "otelConfig": "service: {}\n"}
+    sd = _env_secret(render_helm_template(values))["stringData"]
+    assert sd["INSIGHTS_AGENT_GOMEMLIMIT"] == "819MiB"
+
+
+def test_gomemlimit_computed_from_explicit_limit(render_helm_template, base_values):
+    # Explicit limit -> GOMEMLIMIT = 80% of (limit - requests) = 80% of (2048 - 256) = 1433MiB.
+    values = copy.deepcopy(base_values)
+    values["solace"] = {"size": "dev"}
+    values["insights"]["resources"]["limits"]["memory"] = "2Gi"
+    values["insights"]["forwarding"] = {"enabled": True, "otelConfig": "service: {}\n"}
+    sd = _env_secret(render_helm_template(values))["stringData"]
+    assert sd["INSIGHTS_AGENT_GOMEMLIMIT"] == "1433MiB"
+
+
+def test_gomemlimit_not_injected_in_standard_mode(render_helm_template, base_values):
+    # Standard mode has no OTel collector, so the chart does not derive GOMEMLIMIT.
+    values = copy.deepcopy(base_values)
+    values["solace"] = {"size": "dev"}
+    sd = _env_secret(render_helm_template(values))["stringData"]
+    assert "INSIGHTS_AGENT_GOMEMLIMIT" not in sd
+
+
+def test_gomemlimit_fails_when_explicit_limit_has_no_headroom(render_helm_template, base_values):
+    # Explicit limit not above requests and no operator GOMEMLIMIT -> fail-fast.
+    values = copy.deepcopy(base_values)
+    values["solace"] = {"size": "dev"}
+    values["insights"]["resources"]["limits"]["memory"] = "256Mi"  # == requests
+    values["insights"]["forwarding"] = {"enabled": True, "otelConfig": "service: {}\n"}
+    with pytest.raises(Exception) as e:
+        render_helm_template(values)
+    assert "does not exceed requests" in str(e.value)
 
 
 def test_forwarding_does_not_require_api_key_or_site(render_helm_template, base_values):

--- a/tests/python/unit/test_insights_forwarding.py
+++ b/tests/python/unit/test_insights_forwarding.py
@@ -409,6 +409,37 @@ def test_agent_limits_partial_override(render_helm_template, base_values):
     assert float(container["resources"]["limits"]["cpu"]) == 0.7  # 200m + 500m
 
 
+_SYSTEM_SCALING = {
+    "maxConnections": 100,
+    "maxQueueMessages": 100,
+    "maxSpoolUsage": 1000,
+    "cpu": "2",
+    "memory": "4000Mi",
+}
+
+
+def test_agent_limits_unknown_size_fails_when_computed(render_helm_template, base_values):
+    # Under systemScaling the broker ignores solace.size (no "Invalid solace.size"),
+    # so an unknown size would otherwise yield silent zero headroom; the helper fails
+    # instead of computing a limit equal to the request.
+    values = copy.deepcopy(base_values)
+    del values["insights"]["resources"]["limits"]
+    values["solace"] = {"size": "bogus", "systemScaling": dict(_SYSTEM_SCALING)}
+    with pytest.raises(Exception) as e:
+        render_helm_template(values)
+    assert "unknown solace.size" in str(e.value)
+
+
+def test_agent_limits_unknown_size_ok_with_explicit_limits(render_helm_template, base_values):
+    # Explicit limits bypass the helper (and its unknown-size guard).
+    values = copy.deepcopy(base_values)
+    values["solace"] = {"size": "bogus", "systemScaling": dict(_SYSTEM_SCALING)}
+    values["insights"]["resources"]["limits"] = {"cpu": "1", "memory": "1Gi"}
+    container = _insights_container(render_helm_template(values))
+    assert container["resources"]["limits"]["memory"] == "1Gi"
+    assert str(container["resources"]["limits"]["cpu"]) == "1"
+
+
 # --------------------------------------------------------------------------- #
 # imagePullPolicy (DATAGO-134542)
 # --------------------------------------------------------------------------- #

--- a/tests/python/unit/test_insights_forwarding.py
+++ b/tests/python/unit/test_insights_forwarding.py
@@ -1,0 +1,336 @@
+import base64
+import copy
+
+import pytest
+
+
+@pytest.fixture
+def base_values(cleanup_test_values):
+    return {
+        "insights": {
+            "enabled": True,
+            "environmentVariables": {
+                "INSIGHTS_AGENT_API_KEY": "unused",
+                "INSIGHTS_AGENT_SITE": "datadoghq.com",
+                "INSIGHTS_AGENT_TAGS": "env:dev",
+            },
+            "image": {
+                "repository": "gcr.io/gcp-maas-prod/solace-insights-agent",
+                "tag": "latest",
+            },
+            "resources": {
+                "requests": {"cpu": "200m", "memory": "256Mi"},
+                "limits": {"cpu": "200m", "memory": "512Mi"},
+            },
+        }
+    }
+
+
+def _env_secret(resources):
+    return next(
+        (
+            r
+            for r in resources
+            if r["kind"] == "Secret"
+            and "insights-agent-env-secrets" in r["metadata"]["name"]
+        ),
+        None,
+    )
+
+
+def _otel_secret(resources):
+    return next(
+        (
+            r
+            for r in resources
+            if r["kind"] == "Secret" and r["metadata"]["name"].endswith("-otel-config")
+        ),
+        None,
+    )
+
+
+def _logs_configmap(resources):
+    return next(
+        (
+            r
+            for r in resources
+            if r["kind"] == "ConfigMap" and r["metadata"]["name"].endswith("-logs-config")
+        ),
+        None,
+    )
+
+
+def _insights_container(resources):
+    stateful_set = next(r for r in resources if r["kind"] == "StatefulSet")
+    containers = stateful_set["spec"]["template"]["spec"]["containers"]
+    return next(c for c in containers if c["name"] == "insights-agent")
+
+
+def _volumes(resources):
+    stateful_set = next(r for r in resources if r["kind"] == "StatefulSet")
+    return stateful_set["spec"]["template"]["spec"]["volumes"]
+
+
+# --------------------------------------------------------------------------- #
+# Forwarding-only mode
+# --------------------------------------------------------------------------- #
+def test_forwarding_only_renders_otel_secret_and_mount(render_helm_template, base_values):
+    values = copy.deepcopy(base_values)
+    values["insights"]["forwarding"] = {
+        "enabled": True,
+        "otelConfig": "service:\n  pipelines: {}\n",
+    }
+    resources = render_helm_template(values)
+
+    # Chart-managed OTel config Secret is rendered.
+    otel_secret = _otel_secret(resources)
+    assert otel_secret is not None
+    assert "otel-config.yaml" in otel_secret["stringData"]
+
+    # Only SOLACE_CUSTOM_INSIGHTS_ENABLED is chart-managed in stringData.
+    env_secret = _env_secret(resources)
+    assert env_secret["stringData"]["SOLACE_CUSTOM_INSIGHTS_ENABLED"] == "true"
+    # The chart no longer injects GOMEMLIMIT or the push env vars; those are
+    # operator-supplied via environmentVariables only.
+    assert "INSIGHTS_AGENT_GOMEMLIMIT" not in env_secret["stringData"]
+    assert "INSIGHTS_AGENT_LOGS_ENABLED" not in env_secret["stringData"]
+    assert "INSIGHTS_AGENT_ADDITIONAL_ENDPOINTS" not in env_secret["stringData"]
+
+    # Volume + volumeMount wired to the chart-managed Secret.
+    mount = next(
+        m
+        for m in _insights_container(resources)["volumeMounts"]
+        if m["name"] == "otel-config"
+    )
+    assert mount["mountPath"] == "/etc/datadog-agent/otel-config.yaml"
+    assert mount["subPath"] == "otel-config.yaml"
+    assert mount["readOnly"] is True
+
+    volume = next(v for v in _volumes(resources) if v["name"] == "otel-config")
+    assert volume["secret"]["secretName"].endswith("-otel-config")
+
+
+# --------------------------------------------------------------------------- #
+# Forwarding-mode agent settings (GOMEMLIMIT + Datadog push) — raw env vars,
+# not chart fields; passed through verbatim.
+# --------------------------------------------------------------------------- #
+def test_forwarding_env_vars_pass_through(render_helm_template, base_values):
+    # The chart has no datadogPush or gomemLimit field; the operator supplies these
+    # env vars directly under environmentVariables and the chart passes them through
+    # (into the env-secret's `data` block, base64-encoded like the other env vars).
+    additional = '{"https://app.datadoghq.com":["KEY1","KEY2"]}'
+    logs_cfg = (
+        '[{"api_key":"KEY1","host":"agent-http-intake.logs.datadoghq.com",'
+        '"use_compression":true,"compression_level":2}]'
+    )
+    values = copy.deepcopy(base_values)
+    values["insights"]["environmentVariables"].update(
+        {
+            "INSIGHTS_AGENT_GOMEMLIMIT": "410MiB",
+            "INSIGHTS_AGENT_LOGS_ENABLED": "true",
+            "INSIGHTS_AGENT_ADDITIONAL_ENDPOINTS": additional,
+            "INSIGHTS_AGENT_LOGS_CONFIG_ADDITIONAL_ENDPOINTS": logs_cfg,
+        }
+    )
+    values["insights"]["forwarding"] = {"enabled": True, "otelConfig": "service: {}\n"}
+    env_secret = _env_secret(render_helm_template(values))
+
+    data = env_secret["data"]
+    assert base64.b64decode(data["INSIGHTS_AGENT_GOMEMLIMIT"]).decode() == "410MiB"
+    assert base64.b64decode(data["INSIGHTS_AGENT_LOGS_ENABLED"]).decode() == "true"
+    assert base64.b64decode(data["INSIGHTS_AGENT_ADDITIONAL_ENDPOINTS"]).decode() == additional
+    assert (
+        base64.b64decode(data["INSIGHTS_AGENT_LOGS_CONFIG_ADDITIONAL_ENDPOINTS"]).decode()
+        == logs_cfg
+    )
+
+    # The chart must NOT emit its own copies into stringData (no clobbering).
+    string_data = env_secret.get("stringData", {})
+    assert "INSIGHTS_AGENT_GOMEMLIMIT" not in string_data
+    assert "INSIGHTS_AGENT_LOGS_ENABLED" not in string_data
+    assert "INSIGHTS_AGENT_ADDITIONAL_ENDPOINTS" not in string_data
+    assert "INSIGHTS_AGENT_LOGS_CONFIG_ADDITIONAL_ENDPOINTS" not in string_data
+
+
+# --------------------------------------------------------------------------- #
+# Backward compatibility
+# --------------------------------------------------------------------------- #
+def test_forwarding_disabled_is_noop(render_helm_template, base_values):
+    resources = render_helm_template(base_values)  # no forwarding block at all
+
+    assert _otel_secret(resources) is None
+
+    env_secret = _env_secret(resources)
+    assert "SOLACE_CUSTOM_INSIGHTS_ENABLED" not in env_secret.get("stringData", {})
+
+    assert all(v["name"] != "otel-config" for v in _volumes(resources))
+    assert all(
+        m["name"] != "otel-config"
+        for m in _insights_container(resources)["volumeMounts"]
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Agent logs.yml override (ConfigMap)
+# --------------------------------------------------------------------------- #
+def test_logs_override_inline_renders_configmap_and_mount(render_helm_template, base_values):
+    values = copy.deepcopy(base_values)
+    values["insights"]["forwarding"] = {
+        "enabled": True,
+        "otelConfig": "service: {}\n",
+        "logsConfig": "logs:\n  - type: file\n    path: /jail/logs/*.log\n",
+    }
+    resources = render_helm_template(values)
+
+    cm = _logs_configmap(resources)
+    assert cm is not None
+    assert "logs.yml" in cm["data"]
+    assert "/jail/logs/*.log" in cm["data"]["logs.yml"]
+
+    mount = next(
+        m
+        for m in _insights_container(resources)["volumeMounts"]
+        if m["name"] == "logs-config"
+    )
+    assert mount["mountPath"] == "/etc/datadog-agent/conf.d/solace.d/logs.yml"
+    assert mount["subPath"] == "logs.yml"
+    assert mount["readOnly"] is True
+
+    volume = next(v for v in _volumes(resources) if v["name"] == "logs-config")
+    assert volume["configMap"]["name"].endswith("-logs-config")
+
+
+def test_logs_override_ignored_without_forwarding_block(render_helm_template, base_values):
+    # No logs override and no forwarding -> no logs ConfigMap / volume.
+    resources = render_helm_template(base_values)
+    assert _logs_configmap(resources) is None
+    assert all(v["name"] != "logs-config" for v in _volumes(resources))
+
+
+def test_logs_override_requires_forwarding(render_helm_template, base_values):
+    values = copy.deepcopy(base_values)
+    values["insights"]["forwarding"] = {"logsConfig": "logs: []\n"}  # forwarding disabled
+    with pytest.raises(Exception) as e:
+        render_helm_template(values)
+    assert "only takes effect when insights.forwarding.enabled=true" in str(e.value)
+
+
+# --------------------------------------------------------------------------- #
+# insights-agent resource limits: computed when not set, verbatim when set.
+# Computed base = requests value (else 256Mi / 200m) + per-size-class headroom.
+# --------------------------------------------------------------------------- #
+def test_agent_limits_computed_from_default_base(render_helm_template, base_values):
+    values = copy.deepcopy(base_values)
+    del values["insights"]["resources"]["limits"]  # not provided -> computed
+    values["solace"] = {"size": "dev"}
+    container = _insights_container(render_helm_template(values))
+    # requests base 256Mi/200m + dev headroom 512Mi/500m.
+    assert container["resources"]["limits"]["memory"] == "768Mi"
+    assert float(container["resources"]["limits"]["cpu"]) == 0.7
+
+
+def test_agent_limits_computed_base_follows_requests(render_helm_template, base_values):
+    values = copy.deepcopy(base_values)
+    del values["insights"]["resources"]["limits"]
+    values["insights"]["resources"]["requests"] = {"cpu": "1", "memory": "1Gi"}
+    values["solace"] = {"size": "prod10k"}
+    container = _insights_container(render_helm_template(values))
+    # base = requests (1Gi=1024Mi / 1 core) + prod10k headroom (2048Mi / 1000m).
+    assert container["resources"]["limits"]["memory"] == "3072Mi"
+    assert float(container["resources"]["limits"]["cpu"]) == 2.0
+
+
+def test_agent_limits_verbatim_when_set(render_helm_template, base_values):
+    values = copy.deepcopy(base_values)
+    values["solace"] = {"size": "prod10k"}  # large delta, but explicit values win
+    values["insights"]["resources"]["limits"] = {"cpu": "1", "memory": "2Gi"}
+    container = _insights_container(render_helm_template(values))
+    assert str(container["resources"]["limits"]["cpu"]) == "1"
+    assert container["resources"]["limits"]["memory"] == "2Gi"
+
+
+def test_agent_limits_fractional_mi_request_not_below_request(render_helm_template, base_values):
+    # Regression: a fractional-Mi request must not parse to 0 and yield a limit
+    # below the request (which k8s would reject). 1536.5Mi ceils to 1537 + 512 = 2049Mi.
+    values = copy.deepcopy(base_values)
+    del values["insights"]["resources"]["limits"]
+    values["insights"]["resources"]["requests"] = {"cpu": "200m", "memory": "1536.5Mi"}
+    values["solace"] = {"size": "dev"}
+    container = _insights_container(render_helm_template(values))
+    assert container["resources"]["limits"]["memory"] == "2049Mi"
+
+
+def test_agent_limits_fractional_gi_request(render_helm_template, base_values):
+    values = copy.deepcopy(base_values)
+    del values["insights"]["resources"]["limits"]
+    values["insights"]["resources"]["requests"] = {"cpu": "200m", "memory": "1.5Gi"}
+    values["solace"] = {"size": "prod1k"}
+    container = _insights_container(render_helm_template(values))
+    # 1.5Gi = 1536Mi + prod1k headroom 1024Mi.
+    assert container["resources"]["limits"]["memory"] == "2560Mi"
+
+
+def test_agent_limits_rejects_non_mi_gi_memory(render_helm_template, base_values):
+    values = copy.deepcopy(base_values)
+    del values["insights"]["resources"]["limits"]
+    values["insights"]["resources"]["requests"] = {"cpu": "200m", "memory": "512Ki"}
+    values["solace"] = {"size": "dev"}
+    with pytest.raises(Exception) as e:
+        render_helm_template(values)
+    assert "must be specified in Mi or Gi" in str(e.value)
+
+
+def test_agent_limits_fractional_millicore_cpu_not_truncated(render_helm_template, base_values):
+    # "100.5m" must not truncate to 0; ceil(100.5)=101 + dev 500m = 601m = 0.601 cores.
+    values = copy.deepcopy(base_values)
+    del values["insights"]["resources"]["limits"]
+    values["insights"]["resources"]["requests"] = {"cpu": "100.5m", "memory": "256Mi"}
+    values["solace"] = {"size": "dev"}
+    container = _insights_container(render_helm_template(values))
+    assert float(container["resources"]["limits"]["cpu"]) == 0.601
+
+
+def test_agent_limits_partial_override(render_helm_template, base_values):
+    # memory provided -> verbatim; cpu omitted -> computed from requests base.
+    values = copy.deepcopy(base_values)
+    values["solace"] = {"size": "dev"}
+    values["insights"]["resources"]["limits"] = {"memory": "900Mi"}
+    container = _insights_container(render_helm_template(values))
+    assert container["resources"]["limits"]["memory"] == "900Mi"
+    assert float(container["resources"]["limits"]["cpu"]) == 0.7  # 200m + 500m
+
+
+# --------------------------------------------------------------------------- #
+# imagePullPolicy (DATAGO-134542)
+# --------------------------------------------------------------------------- #
+def test_insights_pull_policy_default_always(render_helm_template, base_values):
+    container = _insights_container(render_helm_template(base_values))
+    assert container["imagePullPolicy"] == "Always"
+
+
+def test_insights_pull_policy_override(render_helm_template, base_values):
+    values = copy.deepcopy(base_values)
+    values["insights"]["image"]["pullPolicy"] = "IfNotPresent"
+    container = _insights_container(render_helm_template(values))
+    assert container["imagePullPolicy"] == "IfNotPresent"
+
+
+# --------------------------------------------------------------------------- #
+# Fail-fast validation
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        {
+            "name": "forwarding_without_config",
+            "forwarding": {"enabled": True},
+            "expected_error": "requires insights.forwarding.otelConfig",
+        },
+    ],
+)
+def test_forwarding_fail_fast(render_helm_template, base_values, test_case):
+    values = copy.deepcopy(base_values)
+    values["insights"]["forwarding"] = test_case["forwarding"]
+    with pytest.raises(Exception) as e:
+        render_helm_template(values)
+    assert test_case["expected_error"] in str(e.value)

--- a/tests/python/unit/test_insights_forwarding.py
+++ b/tests/python/unit/test_insights_forwarding.py
@@ -480,6 +480,52 @@ def test_agent_limits_rejects_non_mi_gi_memory(render_helm_template, base_values
     assert "must be specified in Mi or Gi" in str(e.value)
 
 
+# --------------------------------------------------------------------------- #
+# Full per-size matrix: computed memory/CPU limits and derived GOMEMLIMIT, with
+# default requests (256Mi / 200m). Locks the hand-maintained delta maps for every
+# solace.size tier in one place so a drift in any tier is caught.
+# --------------------------------------------------------------------------- #
+SIZE_MATRIX = {
+    "dev": ("768Mi", 0.7, "409MiB"),
+    "prod1k": ("1280Mi", 0.7, "819MiB"),
+    "prod10k": ("2304Mi", 1.2, "1638MiB"),
+    "prod100k": ("4352Mi", 2.2, "3276MiB"),
+    "prod200k": ("5888Mi", 2.2, "4505MiB"),
+}
+
+
+@pytest.mark.parametrize("size,expected", list(SIZE_MATRIX.items()))
+def test_computed_limits_and_gomemlimit_per_size(render_helm_template, base_values, size, expected):
+    exp_mem, exp_cpu, exp_gom = expected
+    values = copy.deepcopy(base_values)
+    values["solace"] = {"size": size}
+    del values["insights"]["resources"]["limits"]  # computed
+    values["insights"]["forwarding"] = {"enabled": True, "otelConfig": "service: {}\n"}
+    resources = render_helm_template(values)
+    container = _insights_container(resources)
+    assert container["resources"]["limits"]["memory"] == exp_mem
+    assert float(container["resources"]["limits"]["cpu"]) == exp_cpu
+    sd = _env_secret(resources)["stringData"]
+    assert sd["INSIGHTS_AGENT_GOMEMLIMIT"] == exp_gom
+
+
+# --------------------------------------------------------------------------- #
+# TLS: the insights SEMP connection uses the secure port/protocol.
+# --------------------------------------------------------------------------- #
+def test_tls_enabled_uses_https_semp_port(render_helm_template, base_values):
+    values = copy.deepcopy(base_values)
+    values["tls"] = {"enabled": True, "serverCertificatesSecret": "dummy-tls"}
+    sd = _env_secret(render_helm_template(values))["stringData"]
+    assert sd["INSIGHTS_AGENT_SEMP_PORT"] == "1943"
+    assert sd["INSIGHTS_AGENT_SEMP_PROTOCOL"] == "https"
+
+
+def test_tls_disabled_uses_plain_semp_port(render_helm_template, base_values):
+    sd = _env_secret(render_helm_template(base_values))["stringData"]
+    assert sd["INSIGHTS_AGENT_SEMP_PORT"] == "8080"
+    assert sd["INSIGHTS_AGENT_SEMP_PROTOCOL"] == "http"
+
+
 def test_agent_limits_fractional_millicore_cpu_not_truncated(render_helm_template, base_values):
     # "100.5m" must not truncate to 0; ceil(100.5)=101 + dev 500m = 601m = 0.601 cores.
     values = copy.deepcopy(base_values)

--- a/tests/python/unit/test_insights_forwarding.py
+++ b/tests/python/unit/test_insights_forwarding.py
@@ -49,6 +49,12 @@ def _otel_secret(resources):
     )
 
 
+def _otel_key(idx):
+    # Secret keys are keyed by pod name <fullname>-<ordinal>; the render helper
+    # uses release "test-release", so fullname is "test-release-pubsubplus".
+    return "otel-config-test-release-pubsubplus-{}.yaml".format(idx)
+
+
 def _logs_configmap(resources):
     return next(
         (
@@ -85,7 +91,7 @@ def test_forwarding_only_renders_otel_secret_and_mount(render_helm_template, bas
     # Chart-managed OTel config Secret is rendered (keyed per pod index).
     otel_secret = _otel_secret(resources)
     assert otel_secret is not None
-    assert "otel-config-0.yaml" in otel_secret["stringData"]
+    assert _otel_key(0) in otel_secret["stringData"]
 
     # In forwarding mode the chart manages these two keys in stringData.
     env_secret = _env_secret(resources)
@@ -104,7 +110,7 @@ def test_forwarding_only_renders_otel_secret_and_mount(render_helm_template, bas
         if m["name"] == "otel-config"
     )
     assert mount["mountPath"] == "/etc/datadog-agent/otel-config.yaml"
-    assert mount["subPathExpr"] == "otel-config-$(INSIGHTS_AGENT_NODE_ROLE).yaml"
+    assert mount["subPathExpr"] == "otel-config-$(POD_NAME).yaml"
     assert mount["readOnly"] is True
 
     volume = next(v for v in _volumes(resources) if v["name"] == "otel-config")
@@ -124,9 +130,9 @@ def test_otel_per_node_configs_keyed_by_pod_index(render_helm_template, base_val
         "otelConfigMonitor": "service: {role: monitor}\n",
     }
     sd = _otel_secret(render_helm_template(values))["stringData"]
-    assert "role: primary" in sd["otel-config-0.yaml"]
-    assert "role: backup" in sd["otel-config-1.yaml"]
-    assert "role: monitor" in sd["otel-config-2.yaml"]
+    assert "role: primary" in sd[_otel_key(0)]
+    assert "role: backup" in sd[_otel_key(1)]
+    assert "role: monitor" in sd[_otel_key(2)]
 
 
 def test_otel_per_node_falls_back_to_otel_config(render_helm_template, base_values):
@@ -139,9 +145,9 @@ def test_otel_per_node_falls_back_to_otel_config(render_helm_template, base_valu
         "otelConfigPrimary": "service: {role: primary}\n",
     }
     sd = _otel_secret(render_helm_template(values))["stringData"]
-    assert "role: primary" in sd["otel-config-0.yaml"]
-    assert "role: shared" in sd["otel-config-1.yaml"]
-    assert "role: shared" in sd["otel-config-2.yaml"]
+    assert "role: primary" in sd[_otel_key(0)]
+    assert "role: shared" in sd[_otel_key(1)]
+    assert "role: shared" in sd[_otel_key(2)]
 
 
 def test_otel_non_ha_renders_only_index_0(render_helm_template, base_values):
@@ -149,9 +155,9 @@ def test_otel_non_ha_renders_only_index_0(render_helm_template, base_values):
     values["solace"] = {"size": "dev"}  # redundancy defaults false
     values["insights"]["forwarding"] = {"enabled": True, "otelConfig": "service: {}\n"}
     sd = _otel_secret(render_helm_template(values))["stringData"]
-    assert "otel-config-0.yaml" in sd
-    assert "otel-config-1.yaml" not in sd
-    assert "otel-config-2.yaml" not in sd
+    assert _otel_key(0) in sd
+    assert _otel_key(1) not in sd
+    assert _otel_key(2) not in sd
 
 
 def test_otel_ha_requires_backup_config_when_no_fallback(render_helm_template, base_values):

--- a/tests/python/unit/test_insights_forwarding.py
+++ b/tests/python/unit/test_insights_forwarding.py
@@ -87,9 +87,10 @@ def test_forwarding_only_renders_otel_secret_and_mount(render_helm_template, bas
     assert otel_secret is not None
     assert "otel-config-0.yaml" in otel_secret["stringData"]
 
-    # Only SOLACE_CUSTOM_INSIGHTS_ENABLED is chart-managed in stringData.
+    # In forwarding mode the chart manages these two keys in stringData.
     env_secret = _env_secret(resources)
     assert env_secret["stringData"]["SOLACE_CUSTOM_INSIGHTS_ENABLED"] == "true"
+    assert env_secret["stringData"]["INSIGHTS_AGENT_TELEMETRY_ENABLED"] == "false"
     # The chart no longer injects GOMEMLIMIT or the push env vars; those are
     # operator-supplied via environmentVariables only.
     assert "INSIGHTS_AGENT_GOMEMLIMIT" not in env_secret["stringData"]


### PR DESCRIPTION
## Summary

Adds native chart support for the Solace Insights **forwarding (Agent Pro)** modes, so a single `helm install -f values.yaml` covers standard, forwarding-only, and forwarding + Datadog-push deployments with no out-of-band `kubectl create secret` / `kubectl patch` steps, and `helm upgrade` keeps the config in place.

Jira: DATAGO-134167 (also closes DATAGO-134542 — apply `insights.image.pullPolicy`).

## Changes

- **`insights.forwarding.{enabled, otelConfig, logsConfig}`**
  - `otelConfig` → chart-managed Secret mounted at `/etc/datadog-agent/otel-config.yaml` (required when `forwarding.enabled=true`).
  - `logsConfig` → chart-managed ConfigMap mounted over `/etc/datadog-agent/conf.d/solace.d/logs.yml` (only when `forwarding.enabled=true`).
  - Sets `SOLACE_CUSTOM_INSIGHTS_ENABLED=true` and `INSIGHTS_AGENT_TELEMETRY_ENABLED=false` in forwarding mode.
  - Datadog dual-write (`INSIGHTS_AGENT_ADDITIONAL_ENDPOINTS` / `..._LOGS_CONFIG_ADDITIONAL_ENDPOINTS`) and `INSIGHTS_AGENT_GOMEMLIMIT` are operator-supplied via `insights.environmentVariables` (passthrough).
- **insights-agent resource limits**: used verbatim when set; otherwise computed as the requests value plus a per-`solace.size` OTel headroom (`_helpers.tpl`). `requests` default to `256Mi`/`200m`. Mi/Gi and cores/millicores parsed via `float64`; unsupported memory units fail fast.
- **`insights.image.pullPolicy`** (default `Always`) now applied to the agent container (DATAGO-134542).
- **Fail-fast validation**: `forwarding.enabled` requires `otelConfig`; `logsConfig` only takes effect with `forwarding.enabled`.
- Updated `values.schema.json`, `NOTES.txt`, `INSIGHTS.md`; bumped chart to **3.10.0**.

## Testing

- `helm lint` clean.
- New `tests/python/unit/test_insights_forwarding.py` + updated `test_insights.py`; full unit suite passes (37 tests), covering all three modes, gating, validation, resource-limit computation, and unit-parsing edge cases.

## Notes

- When `solace.systemScaling` is used (so `solace.size` is ignored for broker sizing), the computed agent headroom falls back to the `solace.size` default tier — set `insights.resources.limits` explicitly to size the agent for a custom-scaled broker (documented in `values.yaml`/`INSIGHTS.md`).
