### PR TITLE
DATAGO-140643: Rename SOLACE_CUSTOM_INSIGHTS_ENABLED to INSIGHTS_AGENT_THIRD_PARTY_FORWARDING_ENABLED

### DIFF
--- a/pubsubplus/templates/insights-agent-secret.yaml
+++ b/pubsubplus/templates/insights-agent-secret.yaml
@@ -90,7 +90,7 @@ data:
          Keep this list in sync with the stringData keys. */ -}}
   {{- $managedKeys := list "INSIGHTS_AGENT_BROKER_HOSTNAME" "INSIGHTS_AGENT_SEMP_USERNAME" "INSIGHTS_AGENT_SEMP_PASSWORD" "INSIGHTS_AGENT_SEMP_PORT" "INSIGHTS_AGENT_SEMP_PROTOCOL" "INSIGHTS_AGENT_HEALTH_CHECK_PORT" }}
   {{- if .Values.insights.forwarding.enabled }}
-  {{- $managedKeys = concat $managedKeys (list "SOLACE_CUSTOM_INSIGHTS_ENABLED" "INSIGHTS_AGENT_TELEMETRY_ENABLED") }}
+  {{- $managedKeys = concat $managedKeys (list "INSIGHTS_AGENT_THIRD_PARTY_FORWARDING_ENABLED" "INSIGHTS_AGENT_TELEMETRY_ENABLED") }}
   {{- end }}
   {{- /* INSIGHTS_AGENT_API_KEY / INSIGHTS_AGENT_SITE default to "" in the chart values and
          Helm merges those empty defaults in even when the operator omits them. In forwarding
@@ -114,7 +114,7 @@ stringData:
   INSIGHTS_AGENT_SEMP_PROTOCOL: {{ template "insightsAgent.sempProtocol" . }}
   INSIGHTS_AGENT_HEALTH_CHECK_PORT: "5550"
 {{- if .Values.insights.forwarding.enabled }}
-  SOLACE_CUSTOM_INSIGHTS_ENABLED: "true"
+  INSIGHTS_AGENT_THIRD_PARTY_FORWARDING_ENABLED: "true"
   INSIGHTS_AGENT_TELEMETRY_ENABLED: "false"
   {{- /* Derive GOMEMLIMIT for the OTel collector from the agent memory headroom when the
          operator has not set it. If they set it under environmentVariables it passes

--- a/tests/python/unit/test_insights_forwarding.py
+++ b/tests/python/unit/test_insights_forwarding.py
@@ -95,7 +95,7 @@ def test_forwarding_only_renders_otel_secret_and_mount(render_helm_template, bas
 
     # In forwarding mode the chart manages these keys in stringData.
     env_secret = _env_secret(resources)
-    assert env_secret["stringData"]["SOLACE_CUSTOM_INSIGHTS_ENABLED"] == "true"
+    assert env_secret["stringData"]["INSIGHTS_AGENT_THIRD_PARTY_FORWARDING_ENABLED"] == "true"
     assert env_secret["stringData"]["INSIGHTS_AGENT_TELEMETRY_ENABLED"] == "false"
     # GOMEMLIMIT is derived from the agent memory headroom when the operator did not
     # set it: 80% of (limits.memory - requests.memory) = 80% of (512Mi - 256Mi) = 204MiB.
@@ -126,7 +126,7 @@ def test_chart_managed_keys_not_duplicated_in_data(render_helm_template, base_va
     values["insights"]["environmentVariables"].update(
         {
             "INSIGHTS_AGENT_SEMP_PORT": "9999",          # chart-managed (always)
-            "SOLACE_CUSTOM_INSIGHTS_ENABLED": "false",   # chart-managed (forwarding only)
+            "INSIGHTS_AGENT_THIRD_PARTY_FORWARDING_ENABLED": "false",   # chart-managed (forwarding only)
             "MY_CUSTOM_VAR": "keepme",                    # operator-supplied
         }
     )
@@ -136,10 +136,10 @@ def test_chart_managed_keys_not_duplicated_in_data(render_helm_template, base_va
 
     assert base64.b64decode(data["MY_CUSTOM_VAR"]).decode() == "keepme"
     assert "INSIGHTS_AGENT_SEMP_PORT" not in data
-    assert "SOLACE_CUSTOM_INSIGHTS_ENABLED" not in data
+    assert "INSIGHTS_AGENT_THIRD_PARTY_FORWARDING_ENABLED" not in data
     # They appear once, in stringData, with the chart's values (operator value ignored).
     assert string_data["INSIGHTS_AGENT_SEMP_PORT"] == "8080"
-    assert string_data["SOLACE_CUSTOM_INSIGHTS_ENABLED"] == "true"
+    assert string_data["INSIGHTS_AGENT_THIRD_PARTY_FORWARDING_ENABLED"] == "true"
 
 
 # --------------------------------------------------------------------------- #
@@ -361,7 +361,7 @@ def test_forwarding_disabled_is_noop(render_helm_template, base_values):
     assert _otel_secret(resources) is None
 
     env_secret = _env_secret(resources)
-    assert "SOLACE_CUSTOM_INSIGHTS_ENABLED" not in env_secret.get("stringData", {})
+    assert "INSIGHTS_AGENT_THIRD_PARTY_FORWARDING_ENABLED" not in env_secret.get("stringData", {})
 
     assert all(v["name"] != "otel-config" for v in _volumes(resources))
     assert all(


### PR DESCRIPTION
## Summary

Renames the chart-managed forwarding flag `SOLACE_CUSTOM_INSIGHTS_ENABLED` to `INSIGHTS_AGENT_THIRD_PARTY_FORWARDING_ENABLED`, aligning it with the `INSIGHTS_AGENT_*` naming convention used by every other agent environment variable.

In forwarding mode (`insights.forwarding.enabled`), the `insights-agent` env secret now emits `INSIGHTS_AGENT_THIRD_PARTY_FORWARDING_ENABLED: "true"` instead of `SOLACE_CUSTOM_INSIGHTS_ENABLED: "true"`. The agent entrypoint (`solace-datadog-agent`) bridges the new name to the legacy internal variable, so the OTel-redirect / Agent Pro behavior is unchanged.

## Changes

- `pubsubplus/templates/insights-agent-secret.yaml`
  - `stringData`: emit `INSIGHTS_AGENT_THIRD_PARTY_FORWARDING_ENABLED` (forwarding mode only)
  - managed-keys exclusion list updated to the new key so it is not duplicated across the `data` and `stringData` blocks
- `tests/python/unit/test_insights_forwarding.py`
  - assertions updated to the new key name (forwarding-only, no-duplication, and forwarding-disabled no-op cases)

## Related repos

This is the chart side of a coordinated rename across:
- `maas-monitoring` — backend emits the new key in `additionalInsightsAgentEnv`
- `solace-datadog-agent` — entrypoint reads `INSIGHTS_AGENT_THIRD_PARTY_FORWARDING_ENABLED` and bridges it to the legacy internal name

## Testing

- `pytest tests/python/unit/test_insights_forwarding.py` — **42 passed** (conftest renders the real Helm template, validating both chart output and tests)