### PR TITLE
DATAGO-143814: pass broker scaling tier to the agent instead of computing GOMEMLIMIT

### DIFF
--- a/pubsubplus/templates/insights-agent-secret.yaml
+++ b/pubsubplus/templates/insights-agent-secret.yaml
@@ -84,10 +84,12 @@ metadata:
   name: {{ template "solace.fullname" . }}-insights-agent-env-secrets
 type: Opaque
 data:
-  {{- /* Keys the chart manages in the stringData block below. Exclude them from the
-         operator-supplied environmentVariables loop so they are not emitted in both
-         data and stringData with conflicting server-side merge precedence.
-         Keep this list in sync with the stringData keys. */ -}}
+  {{- /* Keys the chart manages directly in the data block below (b64-encoded, alongside the
+         operator vars). Exclude them from the operator environmentVariables loop so a key is
+         never emitted twice in the same map. They live in data (not stringData) so helm's
+         3-way merge prunes any key dropped on a later upgrade; stringData is folded into data
+         by the API server and would otherwise leave stale keys behind.
+         Keep this list in sync with the managed keys emitted below. */ -}}
   {{- $managedKeys := list "INSIGHTS_AGENT_BROKER_HOSTNAME" "INSIGHTS_AGENT_SEMP_USERNAME" "INSIGHTS_AGENT_SEMP_PASSWORD" "INSIGHTS_AGENT_SEMP_PORT" "INSIGHTS_AGENT_SEMP_PROTOCOL" "INSIGHTS_AGENT_HEALTH_CHECK_PORT" }}
   {{- if .Values.insights.forwarding.enabled }}
   {{- $managedKeys = concat $managedKeys (list "INSIGHTS_AGENT_THIRD_PARTY_FORWARDING_ENABLED" "INSIGHTS_AGENT_TELEMETRY_ENABLED") }}
@@ -106,21 +108,20 @@ data:
   {{- end }}
   {{- end }}
   {{- end }}
-stringData:
-  INSIGHTS_AGENT_BROKER_HOSTNAME: "localhost"
-  INSIGHTS_AGENT_SEMP_USERNAME: "insights"
-  INSIGHTS_AGENT_SEMP_PASSWORD: {{ $insightsPasswordValue | quote }}
-  INSIGHTS_AGENT_SEMP_PORT: "{{ template "insightsAgent.sempPort" . }}"
-  INSIGHTS_AGENT_SEMP_PROTOCOL: {{ template "insightsAgent.sempProtocol" . }}
-  INSIGHTS_AGENT_HEALTH_CHECK_PORT: "5550"
+  INSIGHTS_AGENT_BROKER_HOSTNAME: {{ "localhost" | b64enc | quote }}
+  INSIGHTS_AGENT_SEMP_USERNAME: {{ "insights" | b64enc | quote }}
+  INSIGHTS_AGENT_SEMP_PASSWORD: {{ $insightsPasswordValue | b64enc | quote }}
+  INSIGHTS_AGENT_SEMP_PORT: {{ include "insightsAgent.sempPort" . | b64enc | quote }}
+  INSIGHTS_AGENT_SEMP_PROTOCOL: {{ include "insightsAgent.sempProtocol" . | b64enc | quote }}
+  INSIGHTS_AGENT_HEALTH_CHECK_PORT: {{ "5550" | b64enc | quote }}
 {{- if .Values.insights.forwarding.enabled }}
-  INSIGHTS_AGENT_THIRD_PARTY_FORWARDING_ENABLED: "true"
-  INSIGHTS_AGENT_TELEMETRY_ENABLED: "false"
+  INSIGHTS_AGENT_THIRD_PARTY_FORWARDING_ENABLED: {{ "true" | b64enc | quote }}
+  INSIGHTS_AGENT_TELEMETRY_ENABLED: {{ "false" | b64enc | quote }}
   {{- /* By default the chart passes the broker scaling tier (INSIGHTS_AGENT_BROKER_SIZE =
          solace.size with the "prod" prefix stripped) and the datadog-agent maps it to
          GOMEMLIMIT. Two cases keep GOMEMLIMIT chart-computed instead:
            1. the operator set INSIGHTS_AGENT_GOMEMLIMIT explicitly (it passes through the
-              data block above; do not emit it here too), or
+              operator range loop above; do not emit it here too), or
            2. the operator overrode insights.resources.limits.memory -- the agent's fixed
               per-tier map would not reflect that custom limit. Only an explicit
               limits.memory counts, not a requests-driven clamp; operator guidance for
@@ -133,9 +134,9 @@ stringData:
          tier translation, and the bundled insights.image in sync. */ -}}
   {{- if and (not .Values.insights.environmentVariables.INSIGHTS_AGENT_GOMEMLIMIT) (not .Values.insights.environmentVariables.INSIGHTS_AGENT_BROKER_SIZE) }}
   {{- if (.Values.insights.resources.limits | default dict).memory }}
-  INSIGHTS_AGENT_GOMEMLIMIT: {{ include "insights.agentGomemLimit" . | quote }}
+  INSIGHTS_AGENT_GOMEMLIMIT: {{ include "insights.agentGomemLimit" . | b64enc | quote }}
   {{- else }}
-  INSIGHTS_AGENT_BROKER_SIZE: {{ trimPrefix "prod" .Values.solace.size | quote }}
+  INSIGHTS_AGENT_BROKER_SIZE: {{ trimPrefix "prod" .Values.solace.size | b64enc | quote }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/pubsubplus/templates/insights-agent-secret.yaml
+++ b/pubsubplus/templates/insights-agent-secret.yaml
@@ -124,8 +124,17 @@ stringData:
            2. the operator overrode insights.resources.limits.memory -- the agent's fixed
               per-tier map would not reflect that custom limit, so compute GOMEMLIMIT from
               the effective limit here instead of passing the tier.
+         Only an explicit limits.memory counts as (2). A requests-driven clamp (a large
+         insights.resources.requests.memory that raises the *computed* container limit) still
+         passes the tier, so GOMEMLIMIT stays at the per-tier value (safe -- it stays below
+         the container limit -- but does not grow with the request). To match GOMEMLIMIT to a
+         larger footprint, also set insights.resources.limits.memory (or INSIGHTS_AGENT_GOMEMLIMIT).
          An operator-supplied INSIGHTS_AGENT_BROKER_SIZE (data block above) likewise
          suppresses the auto-injected tier to avoid emitting the key twice.
+         Tier-vocabulary contract: the tier passed below is solace.size with the "prod"
+         prefix stripped; the agent's INSIGHTS_AGENT_BROKER_SIZE -> GOMEMLIMIT map
+         (solace-datadog-agent agent/custom-entrypoint.sh) must accept the result
+         {dev,1k,10k,100k,200k}, else it leaves GOMEMLIMIT unset -- keep the two in lockstep.
          NOTE: passing BROKER_SIZE requires an agent image that understands it; with an
          older image GOMEMLIMIT would be left unset (no Go soft limit). Keep the bundled
          insights.image in sync with this behavior. */ -}}

--- a/pubsubplus/templates/insights-agent-secret.yaml
+++ b/pubsubplus/templates/insights-agent-secret.yaml
@@ -116,11 +116,25 @@ stringData:
 {{- if .Values.insights.forwarding.enabled }}
   INSIGHTS_AGENT_THIRD_PARTY_FORWARDING_ENABLED: "true"
   INSIGHTS_AGENT_TELEMETRY_ENABLED: "false"
-  {{- /* Derive GOMEMLIMIT for the OTel collector from the agent memory headroom when the
-         operator has not set it. If they set it under environmentVariables it passes
-         through the data block above, so we must not emit it here too. */ -}}
-  {{- if not .Values.insights.environmentVariables.INSIGHTS_AGENT_GOMEMLIMIT }}
+  {{- /* GOMEMLIMIT is derived by the datadog-agent from the broker scaling tier
+         (INSIGHTS_AGENT_BROKER_SIZE), so by default the chart passes the tier and lets the
+         agent map it. Two cases keep GOMEMLIMIT chart-computed instead:
+           1. the operator set INSIGHTS_AGENT_GOMEMLIMIT explicitly (it passes through the
+              data block above; do not emit it here too), or
+           2. the operator overrode insights.resources.limits.memory -- the agent's fixed
+              per-tier map would not reflect that custom limit, so compute GOMEMLIMIT from
+              the effective limit here instead of passing the tier.
+         An operator-supplied INSIGHTS_AGENT_BROKER_SIZE (data block above) likewise
+         suppresses the auto-injected tier to avoid emitting the key twice.
+         NOTE: passing BROKER_SIZE requires an agent image that understands it; with an
+         older image GOMEMLIMIT would be left unset (no Go soft limit). Keep the bundled
+         insights.image in sync with this behavior. */ -}}
+  {{- if and (not .Values.insights.environmentVariables.INSIGHTS_AGENT_GOMEMLIMIT) (not .Values.insights.environmentVariables.INSIGHTS_AGENT_BROKER_SIZE) }}
+  {{- if (.Values.insights.resources.limits | default dict).memory }}
   INSIGHTS_AGENT_GOMEMLIMIT: {{ include "insights.agentGomemLimit" . | quote }}
+  {{- else }}
+  INSIGHTS_AGENT_BROKER_SIZE: {{ trimPrefix "prod" .Values.solace.size | quote }}
+  {{- end }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/pubsubplus/templates/insights-agent-secret.yaml
+++ b/pubsubplus/templates/insights-agent-secret.yaml
@@ -133,10 +133,18 @@ data:
          without it leaves GOMEMLIMIT unset (no Go soft limit), so keep that map, this
          tier translation, and the bundled insights.image in sync. */ -}}
   {{- if and (not .Values.insights.environmentVariables.INSIGHTS_AGENT_GOMEMLIMIT) (not .Values.insights.environmentVariables.INSIGHTS_AGENT_BROKER_SIZE) }}
+  {{- /* The inactive key of the pair is emitted empty rather than omitted: helm then
+         overwrites it on upgrade instead of relying on pruning, which flushes any stale
+         value left by a stringData-era revision of this Secret (helm cannot prune keys it
+         tracked under stringData, and the dev channel republishes chart 3.10.0 in place, so
+         upgrades can cross that boundary). The agent treats an empty value as unset.
+         Transition hygiene -- removable once dev3.11.0 opens. */ -}}
   {{- if (.Values.insights.resources.limits | default dict).memory }}
   INSIGHTS_AGENT_GOMEMLIMIT: {{ include "insights.agentGomemLimit" . | b64enc | quote }}
+  INSIGHTS_AGENT_BROKER_SIZE: ""
   {{- else }}
   INSIGHTS_AGENT_BROKER_SIZE: {{ trimPrefix "prod" .Values.solace.size | b64enc | quote }}
+  INSIGHTS_AGENT_GOMEMLIMIT: ""
   {{- end }}
   {{- end }}
 {{- end }}

--- a/pubsubplus/templates/insights-agent-secret.yaml
+++ b/pubsubplus/templates/insights-agent-secret.yaml
@@ -116,28 +116,21 @@ stringData:
 {{- if .Values.insights.forwarding.enabled }}
   INSIGHTS_AGENT_THIRD_PARTY_FORWARDING_ENABLED: "true"
   INSIGHTS_AGENT_TELEMETRY_ENABLED: "false"
-  {{- /* GOMEMLIMIT is derived by the datadog-agent from the broker scaling tier
-         (INSIGHTS_AGENT_BROKER_SIZE), so by default the chart passes the tier and lets the
-         agent map it. Two cases keep GOMEMLIMIT chart-computed instead:
+  {{- /* By default the chart passes the broker scaling tier (INSIGHTS_AGENT_BROKER_SIZE =
+         solace.size with the "prod" prefix stripped) and the datadog-agent maps it to
+         GOMEMLIMIT. Two cases keep GOMEMLIMIT chart-computed instead:
            1. the operator set INSIGHTS_AGENT_GOMEMLIMIT explicitly (it passes through the
               data block above; do not emit it here too), or
            2. the operator overrode insights.resources.limits.memory -- the agent's fixed
-              per-tier map would not reflect that custom limit, so compute GOMEMLIMIT from
-              the effective limit here instead of passing the tier.
-         Only an explicit limits.memory counts as (2). A requests-driven clamp (a large
-         insights.resources.requests.memory that raises the *computed* container limit) still
-         passes the tier, so GOMEMLIMIT stays at the per-tier value (safe -- it stays below
-         the container limit -- but does not grow with the request). To match GOMEMLIMIT to a
-         larger footprint, also set insights.resources.limits.memory (or INSIGHTS_AGENT_GOMEMLIMIT).
-         An operator-supplied INSIGHTS_AGENT_BROKER_SIZE (data block above) likewise
-         suppresses the auto-injected tier to avoid emitting the key twice.
-         Tier-vocabulary contract: the tier passed below is solace.size with the "prod"
-         prefix stripped; the agent's INSIGHTS_AGENT_BROKER_SIZE -> GOMEMLIMIT map
-         (solace-datadog-agent agent/custom-entrypoint.sh) must accept the result
-         {dev,1k,10k,100k,200k}, else it leaves GOMEMLIMIT unset -- keep the two in lockstep.
-         NOTE: passing BROKER_SIZE requires an agent image that understands it; with an
-         older image GOMEMLIMIT would be left unset (no Go soft limit). Keep the bundled
-         insights.image in sync with this behavior. */ -}}
+              per-tier map would not reflect that custom limit. Only an explicit
+              limits.memory counts, not a requests-driven clamp; operator guidance for
+              that case lives with the values.yaml environmentVariables docs.
+         An operator-supplied INSIGHTS_AGENT_BROKER_SIZE likewise suppresses the
+         auto-injected tier (no duplicate key).
+         Lockstep contract: the agent's tier map (solace-datadog-agent
+         agent/custom-entrypoint.sh) must accept {dev,1k,10k,100k,200k}; an agent image
+         without it leaves GOMEMLIMIT unset (no Go soft limit), so keep that map, this
+         tier translation, and the bundled insights.image in sync. */ -}}
   {{- if and (not .Values.insights.environmentVariables.INSIGHTS_AGENT_GOMEMLIMIT) (not .Values.insights.environmentVariables.INSIGHTS_AGENT_BROKER_SIZE) }}
   {{- if (.Values.insights.resources.limits | default dict).memory }}
   INSIGHTS_AGENT_GOMEMLIMIT: {{ include "insights.agentGomemLimit" . | quote }}

--- a/pubsubplus/values.yaml
+++ b/pubsubplus/values.yaml
@@ -287,6 +287,8 @@ insights:
     #   # instead computes and passes GOMEMLIMIT (80% of the effective memory headroom, i.e.
     #   # the limit minus the fixed 256Mi base) so the custom limit is respected. Set this
     #   # key only to force an explicit value.
+    #   # Note: raising the footprint via insights.resources.requests.memory alone keeps the
+    #   # per-tier GOMEMLIMIT; set limits.memory too if you want GOMEMLIMIT to grow with it.
     #   INSIGHTS_AGENT_GOMEMLIMIT: "<N>MiB"
     #   # Dual-write to Datadog SaaS in addition to OTel forwarding:
     #   INSIGHTS_AGENT_LOGS_ENABLED: "true"

--- a/pubsubplus/values.yaml
+++ b/pubsubplus/values.yaml
@@ -280,9 +280,13 @@ insights:
     INSIGHTS_AGENT_TAGS: ""
     # Additional agent settings are supplied here as plain env vars and passed through to the
     # agent verbatim. The following are honored only when forwarding.enabled=true:
-    #   # GOMEMLIMIT for the co-resident OTel collector. Optional: when forwarding is enabled and
-    #   # this is not set, the chart derives it as 80% of the agent memory headroom (the effective
-    #   # memory limit minus the fixed 256Mi base). Set it here to override the derived value.
+    #   # GOMEMLIMIT for the datadog-agent (Go soft memory limit); internal, normally unset.
+    #   # When forwarding is enabled the chart passes the broker scaling tier
+    #   # (INSIGHTS_AGENT_BROKER_SIZE, derived from solace.size) and the agent derives
+    #   # GOMEMLIMIT from it. If you override insights.resources.limits.memory, the chart
+    #   # instead computes and passes GOMEMLIMIT (80% of the effective memory headroom, i.e.
+    #   # the limit minus the fixed 256Mi base) so the custom limit is respected. Set this
+    #   # key only to force an explicit value.
     #   INSIGHTS_AGENT_GOMEMLIMIT: "<N>MiB"
     #   # Dual-write to Datadog SaaS in addition to OTel forwarding:
     #   INSIGHTS_AGENT_LOGS_ENABLED: "true"

--- a/tests/python/unit/test_insights_forwarding.py
+++ b/tests/python/unit/test_insights_forwarding.py
@@ -245,16 +245,32 @@ def test_forwarding_env_vars_pass_through(render_helm_template, base_values):
 # --------------------------------------------------------------------------- #
 # Derived INSIGHTS_AGENT_GOMEMLIMIT (forwarding mode, operator value not set)
 # --------------------------------------------------------------------------- #
-def test_gomemlimit_computed_from_size_delta(render_helm_template, base_values):
-    # No explicit limits -> effective limit is requests + per-size headroom, so
-    # GOMEMLIMIT = 80% of that headroom (the OTel collector's share).
-    # prod1k delta = 1024Mi -> 80% = 819MiB.
+def test_broker_size_passed_when_limits_computed(render_helm_template, base_values):
+    # With computed limits (no explicit limits.memory override), the chart passes the
+    # broker scaling tier and lets the agent derive GOMEMLIMIT. solace.size "prod1k" is
+    # translated to the agent's vocabulary "1k" (the "prod" prefix is stripped).
     values = copy.deepcopy(base_values)
     values["solace"] = {"size": "prod1k"}
     del values["insights"]["resources"]["limits"]
     values["insights"]["forwarding"] = {"enabled": True, "otelConfig": "service: {}\n"}
     sd = _env_secret(render_helm_template(values))["stringData"]
-    assert sd["INSIGHTS_AGENT_GOMEMLIMIT"] == "819MiB"
+    assert sd["INSIGHTS_AGENT_BROKER_SIZE"] == "1k"
+    assert "INSIGHTS_AGENT_GOMEMLIMIT" not in sd
+
+
+def test_operator_broker_size_passes_through_and_suppresses_auto_inject(render_helm_template, base_values):
+    # An operator-supplied INSIGHTS_AGENT_BROKER_SIZE passes through the data block and
+    # suppresses the chart's auto-injected tier (no duplicate key) and its GOMEMLIMIT.
+    values = copy.deepcopy(base_values)
+    values["solace"] = {"size": "prod10k"}
+    del values["insights"]["resources"]["limits"]
+    values["insights"]["environmentVariables"]["INSIGHTS_AGENT_BROKER_SIZE"] = "100k"
+    values["insights"]["forwarding"] = {"enabled": True, "otelConfig": "service: {}\n"}
+    sec = _env_secret(render_helm_template(values))
+    assert base64.b64decode(sec["data"]["INSIGHTS_AGENT_BROKER_SIZE"]).decode() == "100k"
+    sd = sec.get("stringData", {})
+    assert "INSIGHTS_AGENT_BROKER_SIZE" not in sd
+    assert "INSIGHTS_AGENT_GOMEMLIMIT" not in sd
 
 
 def test_gomemlimit_computed_from_explicit_limit(render_helm_template, base_values):
@@ -444,7 +460,8 @@ def test_computed_limit_independent_of_requests_below_it(render_helm_template, b
 
 def test_requests_equal_limits_is_guaranteed_qos(render_helm_template, base_values):
     # Set requests to the per-size value and leave limits unset -> requests == limits
-    # (Guaranteed QoS) with a valid derived GOMEMLIMIT (measured from the fixed 256Mi base).
+    # (Guaranteed QoS). Limits are computed (not an explicit limits.memory override), so
+    # the chart passes the tier and the agent derives GOMEMLIMIT (dev -> 409MiB).
     values = copy.deepcopy(base_values)
     del values["insights"]["resources"]["limits"]
     values["solace"] = {"size": "dev"}
@@ -455,12 +472,15 @@ def test_requests_equal_limits_is_guaranteed_qos(render_helm_template, base_valu
     assert c["resources"]["limits"]["memory"] == "768Mi"
     assert c["resources"]["limits"]["memory"] == c["resources"]["requests"]["memory"]
     assert float(c["resources"]["limits"]["cpu"]) == 0.7
-    assert _env_secret(resources)["stringData"]["INSIGHTS_AGENT_GOMEMLIMIT"] == "409MiB"
+    sd = _env_secret(resources)["stringData"]
+    assert sd["INSIGHTS_AGENT_BROKER_SIZE"] == "dev"
+    assert "INSIGHTS_AGENT_GOMEMLIMIT" not in sd
 
 
 def test_computed_limit_clamps_up_to_large_request(render_helm_template, base_values):
-    # A request above base + headroom raises the limit to the request, and GOMEMLIMIT
-    # scales with it (80% of limit - 256Mi base).
+    # A request above base + headroom raises the container limit up to the request. The
+    # chart still passes the tier (a requests-driven clamp is not an explicit limits.memory
+    # override), so GOMEMLIMIT is left to the agent (fixed per tier, not scaled to the clamp).
     values = copy.deepcopy(base_values)
     del values["insights"]["resources"]["limits"]
     values["solace"] = {"size": "dev"}
@@ -468,7 +488,9 @@ def test_computed_limit_clamps_up_to_large_request(render_helm_template, base_va
     values["insights"]["forwarding"] = {"enabled": True, "otelConfig": "service: {}\n"}
     resources = render_helm_template(values)
     assert _insights_container(resources)["resources"]["limits"]["memory"] == "1024Mi"
-    assert _env_secret(resources)["stringData"]["INSIGHTS_AGENT_GOMEMLIMIT"] == "614MiB"
+    sd = _env_secret(resources)["stringData"]
+    assert sd["INSIGHTS_AGENT_BROKER_SIZE"] == "dev"
+    assert "INSIGHTS_AGENT_GOMEMLIMIT" not in sd
 
 
 def test_agent_limits_verbatim_when_set(render_helm_template, base_values):
@@ -512,22 +534,25 @@ def test_agent_limits_rejects_non_mi_gi_memory(render_helm_template, base_values
 
 
 # --------------------------------------------------------------------------- #
-# Full per-size matrix: computed memory/CPU limits and derived GOMEMLIMIT, with
-# default requests (256Mi / 200m). Locks the hand-maintained delta maps for every
-# solace.size tier in one place so a drift in any tier is caught.
+# Full per-size matrix: computed memory/CPU limits (chart) plus the broker scaling
+# tier passed to the agent (INSIGHTS_AGENT_BROKER_SIZE = solace.size with the "prod"
+# prefix stripped), with default requests (256Mi / 200m). Locks the hand-maintained
+# delta maps and the tier translation for every solace.size in one place so a drift in
+# any tier is caught. (The tier -> GOMEMLIMIT mapping is the agent's concern, covered by
+# the agent's own unit tests.)
 # --------------------------------------------------------------------------- #
 SIZE_MATRIX = {
-    "dev": ("768Mi", 0.7, "409MiB"),
-    "prod1k": ("1280Mi", 0.7, "819MiB"),
-    "prod10k": ("2304Mi", 1.2, "1638MiB"),
-    "prod100k": ("4352Mi", 2.2, "3276MiB"),
-    "prod200k": ("5888Mi", 2.2, "4505MiB"),
+    "dev": ("768Mi", 0.7, "dev"),
+    "prod1k": ("1280Mi", 0.7, "1k"),
+    "prod10k": ("2304Mi", 1.2, "10k"),
+    "prod100k": ("4352Mi", 2.2, "100k"),
+    "prod200k": ("5888Mi", 2.2, "200k"),
 }
 
 
 @pytest.mark.parametrize("size,expected", list(SIZE_MATRIX.items()))
-def test_computed_limits_and_gomemlimit_per_size(render_helm_template, base_values, size, expected):
-    exp_mem, exp_cpu, exp_gom = expected
+def test_computed_limits_and_broker_size_per_size(render_helm_template, base_values, size, expected):
+    exp_mem, exp_cpu, exp_broker = expected
     values = copy.deepcopy(base_values)
     values["solace"] = {"size": size}
     del values["insights"]["resources"]["limits"]  # computed
@@ -537,7 +562,8 @@ def test_computed_limits_and_gomemlimit_per_size(render_helm_template, base_valu
     assert container["resources"]["limits"]["memory"] == exp_mem
     assert float(container["resources"]["limits"]["cpu"]) == exp_cpu
     sd = _env_secret(resources)["stringData"]
-    assert sd["INSIGHTS_AGENT_GOMEMLIMIT"] == exp_gom
+    assert sd["INSIGHTS_AGENT_BROKER_SIZE"] == exp_broker
+    assert "INSIGHTS_AGENT_GOMEMLIMIT" not in sd
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/python/unit/test_insights_forwarding.py
+++ b/tests/python/unit/test_insights_forwarding.py
@@ -236,9 +236,11 @@ def test_forwarding_env_vars_pass_through(render_helm_template, base_values):
 
     # The chart must NOT emit its own copies into stringData (no clobbering). For
     # GOMEMLIMIT specifically, an operator-supplied value suppresses the chart's
-    # computed injection so it appears only once (in data).
+    # computed injection so it appears only once (in data) -- and it also suppresses
+    # the auto-injected broker tier (an explicit GOMEMLIMIT makes the tier moot).
     string_data = env_secret.get("stringData", {})
     assert "INSIGHTS_AGENT_GOMEMLIMIT" not in string_data
+    assert "INSIGHTS_AGENT_BROKER_SIZE" not in string_data
     assert "INSIGHTS_AGENT_LOGS_ENABLED" not in string_data
     assert "INSIGHTS_AGENT_ADDITIONAL_ENDPOINTS" not in string_data
     assert "INSIGHTS_AGENT_LOGS_CONFIG_ADDITIONAL_ENDPOINTS" not in string_data
@@ -273,6 +275,24 @@ def test_operator_broker_size_passes_through_and_suppresses_auto_inject(render_h
     sd = sec.get("stringData", {})
     assert "INSIGHTS_AGENT_BROKER_SIZE" not in sd
     assert "INSIGHTS_AGENT_GOMEMLIMIT" not in sd
+
+
+def test_operator_broker_size_with_explicit_limit_emits_neither(render_helm_template, base_values):
+    # Operator-supplied INSIGHTS_AGENT_BROKER_SIZE combined with an explicit
+    # limits.memory override (base_values sets 512Mi): the operator's env var wins over
+    # the explicit-limit rule, so the chart emits neither the computed GOMEMLIMIT nor
+    # the auto-injected tier. The operator's tier passes through the data block and the
+    # agent derives GOMEMLIMIT from it -- which may not reflect the custom limit, but
+    # that is the operator's explicit choice.
+    values = copy.deepcopy(base_values)
+    values["solace"] = {"size": "prod10k"}
+    values["insights"]["environmentVariables"]["INSIGHTS_AGENT_BROKER_SIZE"] = "1k"
+    values["insights"]["forwarding"] = {"enabled": True, "otelConfig": "service: {}\n"}
+    sec = _env_secret(render_helm_template(values))
+    assert base64.b64decode(sec["data"]["INSIGHTS_AGENT_BROKER_SIZE"]).decode() == "1k"
+    sd = sec.get("stringData", {})
+    assert "INSIGHTS_AGENT_GOMEMLIMIT" not in sd
+    assert "INSIGHTS_AGENT_BROKER_SIZE" not in sd
 
 
 def test_gomemlimit_computed_from_explicit_limit(render_helm_template, base_values):

--- a/tests/python/unit/test_insights_forwarding.py
+++ b/tests/python/unit/test_insights_forwarding.py
@@ -38,6 +38,17 @@ def _env_secret(resources):
     )
 
 
+def _env_values(sec):
+    # Effective env the container receives via envFrom. Chart-managed keys and operator
+    # vars all live in `data` (b64-encoded) now; merge any `stringData` too for robustness.
+    out = {}
+    for k, v in (sec.get("data") or {}).items():
+        out[k] = base64.b64decode(v).decode()
+    for k, v in (sec.get("stringData") or {}).items():
+        out[k] = v
+    return out
+
+
 def _otel_secret(resources):
     return next(
         (
@@ -93,18 +104,19 @@ def test_forwarding_only_renders_otel_secret_and_mount(render_helm_template, bas
     assert otel_secret is not None
     assert _otel_key(0) in otel_secret["stringData"]
 
-    # In forwarding mode the chart manages these keys in stringData.
+    # In forwarding mode the chart manages these keys (emitted in the data block, b64).
     env_secret = _env_secret(resources)
-    assert env_secret["stringData"]["INSIGHTS_AGENT_THIRD_PARTY_FORWARDING_ENABLED"] == "true"
-    assert env_secret["stringData"]["INSIGHTS_AGENT_TELEMETRY_ENABLED"] == "false"
+    sd = _env_values(env_secret)
+    assert sd["INSIGHTS_AGENT_THIRD_PARTY_FORWARDING_ENABLED"] == "true"
+    assert sd["INSIGHTS_AGENT_TELEMETRY_ENABLED"] == "false"
     # base_values sets an explicit limits.memory (512Mi), so the chart computes GOMEMLIMIT
     # (80% of the headroom above the fixed 256Mi base = 204MiB) rather than passing the tier.
-    assert env_secret["stringData"]["INSIGHTS_AGENT_GOMEMLIMIT"] == "204MiB"
+    assert sd["INSIGHTS_AGENT_GOMEMLIMIT"] == "204MiB"
     # ...and must NOT also pass the tier (the two are mutually exclusive).
-    assert "INSIGHTS_AGENT_BROKER_SIZE" not in env_secret["stringData"]
+    assert "INSIGHTS_AGENT_BROKER_SIZE" not in sd
     # The Datadog push vars remain operator-supplied via environmentVariables only.
-    assert "INSIGHTS_AGENT_LOGS_ENABLED" not in env_secret["stringData"]
-    assert "INSIGHTS_AGENT_ADDITIONAL_ENDPOINTS" not in env_secret["stringData"]
+    assert "INSIGHTS_AGENT_LOGS_ENABLED" not in sd
+    assert "INSIGHTS_AGENT_ADDITIONAL_ENDPOINTS" not in sd
 
     # Volume + volumeMount wired to the chart-managed Secret.
     mount = next(
@@ -121,9 +133,9 @@ def test_forwarding_only_renders_otel_secret_and_mount(render_helm_template, bas
 
 
 def test_chart_managed_keys_not_duplicated_in_data(render_helm_template, base_values):
-    # Keys the chart manages in stringData must not also be emitted in the data block
-    # (which would create conflicting duplicate keys). Operator-supplied custom vars
-    # still pass through to data.
+    # Chart-managed keys are excluded from the operator range loop and emitted once by the
+    # chart (in data, b64). An operator value for a managed key is ignored (chart wins);
+    # non-managed operator vars still pass through.
     values = copy.deepcopy(base_values)
     values["insights"]["environmentVariables"].update(
         {
@@ -134,14 +146,13 @@ def test_chart_managed_keys_not_duplicated_in_data(render_helm_template, base_va
     )
     values["insights"]["forwarding"] = {"enabled": True, "otelConfig": "service: {}\n"}
     sec = _env_secret(render_helm_template(values))
-    data, string_data = sec["data"], sec["stringData"]
+    ev = _env_values(sec)
 
-    assert base64.b64decode(data["MY_CUSTOM_VAR"]).decode() == "keepme"
-    assert "INSIGHTS_AGENT_SEMP_PORT" not in data
-    assert "INSIGHTS_AGENT_THIRD_PARTY_FORWARDING_ENABLED" not in data
-    # They appear once, in stringData, with the chart's values (operator value ignored).
-    assert string_data["INSIGHTS_AGENT_SEMP_PORT"] == "8080"
-    assert string_data["INSIGHTS_AGENT_THIRD_PARTY_FORWARDING_ENABLED"] == "true"
+    # non-managed operator var passes through
+    assert base64.b64decode(sec["data"]["MY_CUSTOM_VAR"]).decode() == "keepme"
+    # managed keys carry the chart's value, not the operator's override (excluded from the loop)
+    assert ev["INSIGHTS_AGENT_SEMP_PORT"] == "8080"                        # not "9999"
+    assert ev["INSIGHTS_AGENT_THIRD_PARTY_FORWARDING_ENABLED"] == "true"   # not "false"
 
 
 # --------------------------------------------------------------------------- #
@@ -234,16 +245,12 @@ def test_forwarding_env_vars_pass_through(render_helm_template, base_values):
         == logs_cfg
     )
 
-    # The chart must NOT emit its own copies into stringData (no clobbering). For
-    # GOMEMLIMIT specifically, an operator-supplied value suppresses the chart's
-    # computed injection so it appears only once (in data) -- and it also suppresses
-    # the auto-injected broker tier (an explicit GOMEMLIMIT makes the tier moot).
-    string_data = env_secret.get("stringData", {})
-    assert "INSIGHTS_AGENT_GOMEMLIMIT" not in string_data
-    assert "INSIGHTS_AGENT_BROKER_SIZE" not in string_data
-    assert "INSIGHTS_AGENT_LOGS_ENABLED" not in string_data
-    assert "INSIGHTS_AGENT_ADDITIONAL_ENDPOINTS" not in string_data
-    assert "INSIGHTS_AGENT_LOGS_CONFIG_ADDITIONAL_ENDPOINTS" not in string_data
+    # An operator-supplied INSIGHTS_AGENT_GOMEMLIMIT suppresses the chart's auto-injection:
+    # the effective value stays the operator's (not chart-computed) and the broker tier is
+    # NOT emitted (an explicit GOMEMLIMIT makes the tier moot).
+    ev = _env_values(env_secret)
+    assert ev["INSIGHTS_AGENT_GOMEMLIMIT"] == "410MiB"
+    assert "INSIGHTS_AGENT_BROKER_SIZE" not in ev
 
 
 # --------------------------------------------------------------------------- #
@@ -257,7 +264,7 @@ def test_broker_size_passed_when_limits_computed(render_helm_template, base_valu
     values["solace"] = {"size": "prod1k"}
     del values["insights"]["resources"]["limits"]
     values["insights"]["forwarding"] = {"enabled": True, "otelConfig": "service: {}\n"}
-    sd = _env_secret(render_helm_template(values))["stringData"]
+    sd = _env_values(_env_secret(render_helm_template(values)))
     assert sd["INSIGHTS_AGENT_BROKER_SIZE"] == "1k"
     assert "INSIGHTS_AGENT_GOMEMLIMIT" not in sd
 
@@ -271,10 +278,11 @@ def test_operator_broker_size_passes_through_and_suppresses_auto_inject(render_h
     values["insights"]["environmentVariables"]["INSIGHTS_AGENT_BROKER_SIZE"] = "100k"
     values["insights"]["forwarding"] = {"enabled": True, "otelConfig": "service: {}\n"}
     sec = _env_secret(render_helm_template(values))
-    assert base64.b64decode(sec["data"]["INSIGHTS_AGENT_BROKER_SIZE"]).decode() == "100k"
-    sd = sec.get("stringData", {})
-    assert "INSIGHTS_AGENT_BROKER_SIZE" not in sd
-    assert "INSIGHTS_AGENT_GOMEMLIMIT" not in sd
+    ev = _env_values(sec)
+    # operator value passes through; the chart auto-injects neither a duplicate tier nor a
+    # GOMEMLIMIT (had it emitted its own tier for prod10k it would be "10k", not "100k")
+    assert ev["INSIGHTS_AGENT_BROKER_SIZE"] == "100k"
+    assert "INSIGHTS_AGENT_GOMEMLIMIT" not in ev
 
 
 def test_operator_broker_size_with_explicit_limit_emits_neither(render_helm_template, base_values):
@@ -289,10 +297,11 @@ def test_operator_broker_size_with_explicit_limit_emits_neither(render_helm_temp
     values["insights"]["environmentVariables"]["INSIGHTS_AGENT_BROKER_SIZE"] = "1k"
     values["insights"]["forwarding"] = {"enabled": True, "otelConfig": "service: {}\n"}
     sec = _env_secret(render_helm_template(values))
-    assert base64.b64decode(sec["data"]["INSIGHTS_AGENT_BROKER_SIZE"]).decode() == "1k"
-    sd = sec.get("stringData", {})
-    assert "INSIGHTS_AGENT_GOMEMLIMIT" not in sd
-    assert "INSIGHTS_AGENT_BROKER_SIZE" not in sd
+    ev = _env_values(sec)
+    # operator BROKER_SIZE wins over the explicit-limit rule; the chart emits no GOMEMLIMIT and
+    # no duplicate tier (else prod10k would surface as "10k", not the operator's "1k")
+    assert ev["INSIGHTS_AGENT_BROKER_SIZE"] == "1k"
+    assert "INSIGHTS_AGENT_GOMEMLIMIT" not in ev
 
 
 def test_gomemlimit_computed_from_explicit_limit(render_helm_template, base_values):
@@ -301,7 +310,7 @@ def test_gomemlimit_computed_from_explicit_limit(render_helm_template, base_valu
     values["solace"] = {"size": "dev"}
     values["insights"]["resources"]["limits"]["memory"] = "2Gi"
     values["insights"]["forwarding"] = {"enabled": True, "otelConfig": "service: {}\n"}
-    sd = _env_secret(render_helm_template(values))["stringData"]
+    sd = _env_values(_env_secret(render_helm_template(values)))
     assert sd["INSIGHTS_AGENT_GOMEMLIMIT"] == "1433MiB"
     assert "INSIGHTS_AGENT_BROKER_SIZE" not in sd
 
@@ -310,7 +319,7 @@ def test_gomemlimit_not_injected_in_standard_mode(render_helm_template, base_val
     # Standard mode has no OTel collector, so the chart does not derive GOMEMLIMIT.
     values = copy.deepcopy(base_values)
     values["solace"] = {"size": "dev"}
-    sd = _env_secret(render_helm_template(values))["stringData"]
+    sd = _env_values(_env_secret(render_helm_template(values)))
     assert "INSIGHTS_AGENT_GOMEMLIMIT" not in sd
 
 
@@ -400,7 +409,7 @@ def test_forwarding_disabled_is_noop(render_helm_template, base_values):
     assert _otel_secret(resources) is None
 
     env_secret = _env_secret(resources)
-    assert "INSIGHTS_AGENT_THIRD_PARTY_FORWARDING_ENABLED" not in env_secret.get("stringData", {})
+    assert "INSIGHTS_AGENT_THIRD_PARTY_FORWARDING_ENABLED" not in _env_values(env_secret)
 
     assert all(v["name"] != "otel-config" for v in _volumes(resources))
     assert all(
@@ -495,7 +504,7 @@ def test_requests_equal_limits_is_guaranteed_qos(render_helm_template, base_valu
     assert c["resources"]["limits"]["memory"] == "768Mi"
     assert c["resources"]["limits"]["memory"] == c["resources"]["requests"]["memory"]
     assert float(c["resources"]["limits"]["cpu"]) == 0.7
-    sd = _env_secret(resources)["stringData"]
+    sd = _env_values(_env_secret(resources))
     assert sd["INSIGHTS_AGENT_BROKER_SIZE"] == "dev"
     assert "INSIGHTS_AGENT_GOMEMLIMIT" not in sd
 
@@ -511,7 +520,7 @@ def test_computed_limit_clamps_up_to_large_request(render_helm_template, base_va
     values["insights"]["forwarding"] = {"enabled": True, "otelConfig": "service: {}\n"}
     resources = render_helm_template(values)
     assert _insights_container(resources)["resources"]["limits"]["memory"] == "1024Mi"
-    sd = _env_secret(resources)["stringData"]
+    sd = _env_values(_env_secret(resources))
     assert sd["INSIGHTS_AGENT_BROKER_SIZE"] == "dev"
     assert "INSIGHTS_AGENT_GOMEMLIMIT" not in sd
 
@@ -585,7 +594,7 @@ def test_computed_limits_and_broker_size_per_size(render_helm_template, base_val
     container = _insights_container(resources)
     assert container["resources"]["limits"]["memory"] == exp_mem
     assert float(container["resources"]["limits"]["cpu"]) == exp_cpu
-    sd = _env_secret(resources)["stringData"]
+    sd = _env_values(_env_secret(resources))
     assert sd["INSIGHTS_AGENT_BROKER_SIZE"] == exp_broker
     assert "INSIGHTS_AGENT_GOMEMLIMIT" not in sd
 
@@ -596,13 +605,13 @@ def test_computed_limits_and_broker_size_per_size(render_helm_template, base_val
 def test_tls_enabled_uses_https_semp_port(render_helm_template, base_values):
     values = copy.deepcopy(base_values)
     values["tls"] = {"enabled": True, "serverCertificatesSecret": "dummy-tls"}
-    sd = _env_secret(render_helm_template(values))["stringData"]
+    sd = _env_values(_env_secret(render_helm_template(values)))
     assert sd["INSIGHTS_AGENT_SEMP_PORT"] == "1943"
     assert sd["INSIGHTS_AGENT_SEMP_PROTOCOL"] == "https"
 
 
 def test_tls_disabled_uses_plain_semp_port(render_helm_template, base_values):
-    sd = _env_secret(render_helm_template(base_values))["stringData"]
+    sd = _env_values(_env_secret(render_helm_template(base_values)))
     assert sd["INSIGHTS_AGENT_SEMP_PORT"] == "8080"
     assert sd["INSIGHTS_AGENT_SEMP_PROTOCOL"] == "http"
 

--- a/tests/python/unit/test_insights_forwarding.py
+++ b/tests/python/unit/test_insights_forwarding.py
@@ -112,8 +112,10 @@ def test_forwarding_only_renders_otel_secret_and_mount(render_helm_template, bas
     # base_values sets an explicit limits.memory (512Mi), so the chart computes GOMEMLIMIT
     # (80% of the headroom above the fixed 256Mi base = 204MiB) rather than passing the tier.
     assert sd["INSIGHTS_AGENT_GOMEMLIMIT"] == "204MiB"
-    # ...and must NOT also pass the tier (the two are mutually exclusive).
-    assert "INSIGHTS_AGENT_BROKER_SIZE" not in sd
+    # ...and the inactive tier key is emitted EMPTY (not omitted): the agent treats "" as
+    # unset, and helm overwrites the key on upgrade instead of relying on pruning, flushing
+    # any stale value a stringData-era revision left on the live Secret.
+    assert sd["INSIGHTS_AGENT_BROKER_SIZE"] == ""
     # The Datadog push vars remain operator-supplied via environmentVariables only.
     assert "INSIGHTS_AGENT_LOGS_ENABLED" not in sd
     assert "INSIGHTS_AGENT_ADDITIONAL_ENDPOINTS" not in sd
@@ -266,7 +268,8 @@ def test_broker_size_passed_when_limits_computed(render_helm_template, base_valu
     values["insights"]["forwarding"] = {"enabled": True, "otelConfig": "service: {}\n"}
     sd = _env_values(_env_secret(render_helm_template(values)))
     assert sd["INSIGHTS_AGENT_BROKER_SIZE"] == "1k"
-    assert "INSIGHTS_AGENT_GOMEMLIMIT" not in sd
+    # the inactive GOMEMLIMIT key is emitted empty (stale-value clobber; "" = unset to the agent)
+    assert sd["INSIGHTS_AGENT_GOMEMLIMIT"] == ""
 
 
 def test_operator_broker_size_passes_through_and_suppresses_auto_inject(render_helm_template, base_values):
@@ -280,7 +283,8 @@ def test_operator_broker_size_passes_through_and_suppresses_auto_inject(render_h
     sec = _env_secret(render_helm_template(values))
     ev = _env_values(sec)
     # operator value passes through; the chart auto-injects neither a duplicate tier nor a
-    # GOMEMLIMIT (had it emitted its own tier for prod10k it would be "10k", not "100k")
+    # GOMEMLIMIT (had it emitted its own tier for prod10k it would be "10k", not "100k").
+    # No empty-clobber either: the whole chart-managed block is skipped on operator override.
     assert ev["INSIGHTS_AGENT_BROKER_SIZE"] == "100k"
     assert "INSIGHTS_AGENT_GOMEMLIMIT" not in ev
 
@@ -312,15 +316,18 @@ def test_gomemlimit_computed_from_explicit_limit(render_helm_template, base_valu
     values["insights"]["forwarding"] = {"enabled": True, "otelConfig": "service: {}\n"}
     sd = _env_values(_env_secret(render_helm_template(values)))
     assert sd["INSIGHTS_AGENT_GOMEMLIMIT"] == "1433MiB"
-    assert "INSIGHTS_AGENT_BROKER_SIZE" not in sd
+    # the inactive tier key is emitted empty (stale-value clobber; "" = unset to the agent)
+    assert sd["INSIGHTS_AGENT_BROKER_SIZE"] == ""
 
 
 def test_gomemlimit_not_injected_in_standard_mode(render_helm_template, base_values):
-    # Standard mode has no OTel collector, so the chart does not derive GOMEMLIMIT.
+    # Standard mode has no OTel collector, so the chart derives neither GOMEMLIMIT nor a
+    # broker tier (and no empty-clobber keys: the pair is forwarding-mode only).
     values = copy.deepcopy(base_values)
     values["solace"] = {"size": "dev"}
     sd = _env_values(_env_secret(render_helm_template(values)))
     assert "INSIGHTS_AGENT_GOMEMLIMIT" not in sd
+    assert "INSIGHTS_AGENT_BROKER_SIZE" not in sd
 
 
 def test_gomemlimit_fails_when_explicit_limit_has_no_headroom(render_helm_template, base_values):
@@ -506,7 +513,7 @@ def test_requests_equal_limits_is_guaranteed_qos(render_helm_template, base_valu
     assert float(c["resources"]["limits"]["cpu"]) == 0.7
     sd = _env_values(_env_secret(resources))
     assert sd["INSIGHTS_AGENT_BROKER_SIZE"] == "dev"
-    assert "INSIGHTS_AGENT_GOMEMLIMIT" not in sd
+    assert sd["INSIGHTS_AGENT_GOMEMLIMIT"] == ""
 
 
 def test_computed_limit_clamps_up_to_large_request(render_helm_template, base_values):
@@ -522,7 +529,7 @@ def test_computed_limit_clamps_up_to_large_request(render_helm_template, base_va
     assert _insights_container(resources)["resources"]["limits"]["memory"] == "1024Mi"
     sd = _env_values(_env_secret(resources))
     assert sd["INSIGHTS_AGENT_BROKER_SIZE"] == "dev"
-    assert "INSIGHTS_AGENT_GOMEMLIMIT" not in sd
+    assert sd["INSIGHTS_AGENT_GOMEMLIMIT"] == ""
 
 
 def test_agent_limits_verbatim_when_set(render_helm_template, base_values):
@@ -596,7 +603,7 @@ def test_computed_limits_and_broker_size_per_size(render_helm_template, base_val
     assert float(container["resources"]["limits"]["cpu"]) == exp_cpu
     sd = _env_values(_env_secret(resources))
     assert sd["INSIGHTS_AGENT_BROKER_SIZE"] == exp_broker
-    assert "INSIGHTS_AGENT_GOMEMLIMIT" not in sd
+    assert sd["INSIGHTS_AGENT_GOMEMLIMIT"] == ""
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/python/unit/test_insights_forwarding.py
+++ b/tests/python/unit/test_insights_forwarding.py
@@ -97,9 +97,11 @@ def test_forwarding_only_renders_otel_secret_and_mount(render_helm_template, bas
     env_secret = _env_secret(resources)
     assert env_secret["stringData"]["INSIGHTS_AGENT_THIRD_PARTY_FORWARDING_ENABLED"] == "true"
     assert env_secret["stringData"]["INSIGHTS_AGENT_TELEMETRY_ENABLED"] == "false"
-    # GOMEMLIMIT is derived from the agent memory headroom when the operator did not
-    # set it: 80% of (limits.memory - requests.memory) = 80% of (512Mi - 256Mi) = 204MiB.
+    # base_values sets an explicit limits.memory (512Mi), so the chart computes GOMEMLIMIT
+    # (80% of the headroom above the fixed 256Mi base = 204MiB) rather than passing the tier.
     assert env_secret["stringData"]["INSIGHTS_AGENT_GOMEMLIMIT"] == "204MiB"
+    # ...and must NOT also pass the tier (the two are mutually exclusive).
+    assert "INSIGHTS_AGENT_BROKER_SIZE" not in env_secret["stringData"]
     # The Datadog push vars remain operator-supplied via environmentVariables only.
     assert "INSIGHTS_AGENT_LOGS_ENABLED" not in env_secret["stringData"]
     assert "INSIGHTS_AGENT_ADDITIONAL_ENDPOINTS" not in env_secret["stringData"]
@@ -281,6 +283,7 @@ def test_gomemlimit_computed_from_explicit_limit(render_helm_template, base_valu
     values["insights"]["forwarding"] = {"enabled": True, "otelConfig": "service: {}\n"}
     sd = _env_secret(render_helm_template(values))["stringData"]
     assert sd["INSIGHTS_AGENT_GOMEMLIMIT"] == "1433MiB"
+    assert "INSIGHTS_AGENT_BROKER_SIZE" not in sd
 
 
 def test_gomemlimit_not_injected_in_standard_mode(render_helm_template, base_values):
@@ -539,7 +542,8 @@ def test_agent_limits_rejects_non_mi_gi_memory(render_helm_template, base_values
 # prefix stripped), with default requests (256Mi / 200m). Locks the hand-maintained
 # delta maps and the tier translation for every solace.size in one place so a drift in
 # any tier is caught. (The tier -> GOMEMLIMIT mapping is the agent's concern, covered by
-# the agent's own unit tests.)
+# the agent's own unit tests; keep this tier list in lockstep with the agent's
+# INSIGHTS_AGENT_BROKER_SIZE map in solace-datadog-agent agent/custom-entrypoint.sh.)
 # --------------------------------------------------------------------------- #
 SIZE_MATRIX = {
     "dev": ("768Mi", 0.7, "dev"),

--- a/tests/python/unit/test_insights_helpers.py
+++ b/tests/python/unit/test_insights_helpers.py
@@ -1,4 +1,16 @@
+import base64
+
 import pytest
+
+
+def _env_values(sec):
+    # Effective env delivered via envFrom: chart-managed keys live in `data` (b64).
+    out = {}
+    for k, v in (sec.get("data") or {}).items():
+        out[k] = base64.b64decode(v).decode()
+    for k, v in (sec.get("stringData") or {}).items():
+        out[k] = v
+    return out
 
 
 @pytest.fixture
@@ -41,8 +53,9 @@ def test_insights_semp_port_with_tls(render_helm_template, base_values):
     )
     assert env_secret is not None
 
-    assert env_secret["stringData"]["INSIGHTS_AGENT_SEMP_PORT"] == "1943"
-    assert env_secret["stringData"]["INSIGHTS_AGENT_SEMP_PROTOCOL"] == "https"
+    ev = _env_values(env_secret)
+    assert ev["INSIGHTS_AGENT_SEMP_PORT"] == "1943"
+    assert ev["INSIGHTS_AGENT_SEMP_PROTOCOL"] == "https"
 
 
 def test_insights_semp_port_without_tls(render_helm_template, base_values):
@@ -59,8 +72,9 @@ def test_insights_semp_port_without_tls(render_helm_template, base_values):
     )
     assert env_secret is not None
 
-    assert env_secret["stringData"]["INSIGHTS_AGENT_SEMP_PORT"] == "8080"
-    assert env_secret["stringData"]["INSIGHTS_AGENT_SEMP_PROTOCOL"] == "http"
+    ev = _env_values(env_secret)
+    assert ev["INSIGHTS_AGENT_SEMP_PORT"] == "8080"
+    assert ev["INSIGHTS_AGENT_SEMP_PROTOCOL"] == "http"
 
 
 def test_insights_password_generation(render_helm_template, base_values):
@@ -92,7 +106,7 @@ def test_insights_password_generation(render_helm_template, base_values):
         None,
     )
     assert env_secret is not None
-    assert "INSIGHTS_AGENT_SEMP_PASSWORD" in env_secret["stringData"]
+    assert "INSIGHTS_AGENT_SEMP_PASSWORD" in _env_values(env_secret)
 
 
 def test_missing_image_configuration(render_helm_template):


### PR DESCRIPTION
### Jira Link
https://sol-jira.atlassian.net/browse/DATAGO-143814

### Purpose
Move the `INSIGHTS_AGENT_GOMEMLIMIT` derivation out of the chart and into the datadog-agent. In forwarding mode the chart now passes the broker scaling tier as `INSIGHTS_AGENT_BROKER_SIZE` and the agent derives `GOMEMLIMIT` from it (companion to solace-datadog-agent #486).

### How is this accomplished?
`templates/insights-agent-secret.yaml` (forwarding-mode `stringData`):
- **Default:** emit `INSIGHTS_AGENT_BROKER_SIZE = trimPrefix "prod" .Values.solace.size` (`prod10k → 10k`, `dev → dev`) — the agent's vocabulary — and let the agent map the tier to `GOMEMLIMIT`.
- **Keep** computing/passing `INSIGHTS_AGENT_GOMEMLIMIT` instead when the operator overrides `insights.resources.limits.memory` (so a custom limit is respected) or sets `INSIGHTS_AGENT_GOMEMLIMIT` explicitly.
- An operator-supplied `INSIGHTS_AGENT_BROKER_SIZE` suppresses the auto-injected tier (no duplicate key).
- The `insights.agentGomemLimit` helper is **retained** for the override path.
- `solace.size` values and all other broker-sizing logic are unchanged (Path A — non-breaking).

Updated `values.yaml` docs and the `test_insights_forwarding.py` unit tests — all 63 chart unit tests pass; `helm lint` clean.

### Anything reviewers should focus on / be aware of?
- **Agent version coupling (important):** passing `BROKER_SIZE` requires an agent image that understands it (solace-datadog-agent #486). With an older agent image, `GOMEMLIMIT` would be left unset (no Go soft limit → OOM risk under load). The bundled `insights.image` tag must support `BROKER_SIZE` before this merges.
- **Requests-driven clamp:** a large `requests.memory` (with computed limits) still raises the container limit but no longer bumps `GOMEMLIMIT` (now fixed per tier). Safe (the soft limit stays under the cgroup limit) but it no longer maximizes headroom for that edge case — only an explicit `limits.memory` override triggers the computed path, per the ticket.
- **Base branch:** this PR targets `dev3.10.0` (where the prior insights-forwarding work merged), not the repo's reported default `gh-actions-cron`.

_(No PR template exists in this repo, so this description is free-form.)_
